### PR TITLE
docs: prettify README with app icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-# VoiceType 🎙️
+<p align="center">
+  <img src="Resources/AppIcon.png" width="128" height="128" alt="VoiceType icon">
+</p>
 
-Hold a key, speak, release — your words are transcribed and pasted wherever you're typing. Like [Wispr Flow](https://wisprflow.com), but free and open source.
+<h1 align="center">VoiceType</h1>
+
+<p align="center">
+  Hold a key, speak, release — your words are transcribed and pasted wherever you're typing.<br>
+  Like <a href="https://wisprflow.com">Wispr Flow</a>, but free and open source.
+</p>
+
+---
 
 ## Install
 
@@ -18,9 +27,10 @@ Requires macOS 12+ and Xcode Command Line Tools (`xcode-select --install`).
 
 Click the menu bar icon → **Settings** to configure your transcription and formatting providers. Works out of the box with Apple Dictation (free, on-device) — add an API key to upgrade accuracy and enable AI formatting.
 
-**Transcription:** Apple Dictation, Gemini, OpenAI, Deepgram, or ElevenLabs
-
-**Formatting:** Gemini, OpenAI, or Anthropic — with Casual, Formatted, or Professional modes
+| | Providers |
+|---|---|
+| **Transcription** | Apple Dictation, Gemini, OpenAI, Deepgram, ElevenLabs |
+| **Formatting** | Gemini, OpenAI, Anthropic — Casual, Formatted, or Professional |
 
 Gemini can handle both transcription and formatting in a single API call.
 


### PR DESCRIPTION
## Summary
- Centered app icon (128x128) at the top of README
- Centered title and tagline
- Provider info organized in a table

🤖 Generated with [Claude Code](https://claude.com/claude-code)