### PR TITLE
ci: add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build VoiceType.app
+        run: ./build.sh


### PR DESCRIPTION
## Summary
- Runs `./build.sh` on pushes and PRs to master
- Uses `macos-latest` runner with Xcode CLI tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)