### PR TITLE
feat: rename app to Yap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build VoiceType.app
+      - name: Build Yap.app
         run: ./build.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="Resources/AppIcon.png" width="128" height="128" alt="VoiceType icon">
+  <img src="Resources/AppIcon.png" width="128" height="128" alt="Yap icon">
 </p>
 
-<h1 align="center">VoiceType</h1>
+<h1 align="center">Yap</h1>
 
 <p align="center">
   Hold a key, speak, release — your words are transcribed and pasted wherever you're typing.<br>
@@ -13,16 +13,16 @@
 
 ## Install
 
-**Download:** Grab the latest `VoiceType.app.zip` from [Releases](https://github.com/igaboo/voicetype/releases), unzip, and move to `/Applications`.
+**Download:** Grab the latest `Yap.app.zip` from [Releases](https://github.com/igaboo/yap/releases), unzip, and move to `/Applications`.
 
 **Build from source:**
 
 ```bash
-git clone https://github.com/igaboo/voicetype.git
-cd voicetype
+git clone https://github.com/igaboo/yap.git
+cd yap
 ./build.sh
-cp -r build/VoiceType.app /Applications/
-open /Applications/VoiceType.app
+cp -r build/Yap.app /Applications/
+open /Applications/Yap.app
 ```
 
 Requires macOS 12+ and Xcode Command Line Tools (`xcode-select --install`).

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleName</key>
-    <string>VoiceType</string>
+    <string>Yap</string>
     <key>CFBundleIdentifier</key>
-    <string>com.voicetype.app</string>
+    <string>com.yap.app</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
     <key>CFBundleShortVersionString</key>
@@ -13,7 +13,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>
-    <string>VoiceType</string>
+    <string>Yap</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>LSMinimumSystemVersion</key>
@@ -21,8 +21,8 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSMicrophoneUsageDescription</key>
-    <string>VoiceType needs microphone access to record your voice for transcription.</string>
+    <string>Yap needs microphone access to record your voice for transcription.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
-    <string>VoiceType uses on-device speech recognition to transcribe your voice.</string>
+    <string>Yap uses on-device speech recognition to transcribe your voice.</string>
 </dict>
 </plist>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2,12 +2,12 @@ import Cocoa
 import AVFoundation
 import os.log
 
-private let logger = OSLog(subsystem: "com.voicetype.app", category: "general")
+private let logger = OSLog(subsystem: "com.yap.app", category: "general")
 
 func log(_ message: String) {
     os_log("%{public}@", log: logger, type: .default, message)
     let logURL = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".config/voicetype/debug.log")
+        .appendingPathComponent(".config/yap/debug.log")
     let timestamp = ISO8601DateFormatter().string(from: Date())
     let line = "[\(timestamp)] \(message)\n"
     if let handle = try? FileHandle(forWritingTo: logURL) {
@@ -72,7 +72,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         
         let menu = NSMenu()
         
-        let titleItem = NSMenuItem(title: "VoiceType", action: nil, keyEquivalent: "")
+        let titleItem = NSMenuItem(title: "Yap", action: nil, keyEquivalent: "")
         titleItem.isEnabled = false
         menu.addItem(titleItem)
         menu.addItem(NSMenuItem.separator())
@@ -102,12 +102,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             if let customIcon = loadMenuIcon() {
                 button.image = customIcon
             } else {
-                button.image = NSImage(systemSymbolName: "mic", accessibilityDescription: "VoiceType")
+                button.image = NSImage(systemSymbolName: "mic", accessibilityDescription: "Yap")
             }
         case .recording:
-            button.image = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: "VoiceType")
+            button.image = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: "Yap")
         case .processing:
-            button.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: "VoiceType")
+            button.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: "Yap")
         }
     }
     
@@ -165,7 +165,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             log("Microphone permission: \(granted ? "✅" : "❌")")
             if !granted {
                 DispatchQueue.main.async {
-                    self.showNotification(title: "VoiceType", body: "Microphone access required.")
+                    self.showNotification(title: "Yap", body: "Microphone access required.")
                 }
             }
         }
@@ -189,7 +189,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         let started = hotkeyManager.start()
         log("Hotkey (\(hotkeyType)): \(started ? "✅" : "❌ — no Accessibility?")")
         if !started {
-            showNotification(title: "VoiceType", body: "Accessibility permission required.")
+            showNotification(title: "Yap", body: "Accessibility permission required.")
         }
     }
     

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -5,7 +5,7 @@ class AudioRecorder {
     private var engine: AVAudioEngine?
     private var audioFile: AVAudioFile?
     let tempURL = FileManager.default.temporaryDirectory
-        .appendingPathComponent("voicetype_recording.wav")
+        .appendingPathComponent("yap_recording.wav")
 
     /// Called on main thread with per-band levels (array of 0.0-1.0) and overall RMS (0.0-1.0)
     var onLevelUpdate: ((Float) -> Void)?

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -195,7 +195,7 @@ class SettingsWindow: NSWindow {
             defer: false
         )
         
-        title = "VoiceType Settings"
+        title = "Yap Settings"
         isReleasedWhenClosed = false
         center()
         loadUI()
@@ -228,7 +228,7 @@ class SettingsWindow: NSWindow {
     
     static func configURL() -> URL {
         FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/voicetype/config.json")
+            .appendingPathComponent(".config/yap/config.json")
     }
     
     static func loadConfig() -> [String: Any] {

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-APP_NAME="VoiceType"
+APP_NAME="Yap"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 


### PR DESCRIPTION
## Summary
- Renamed everything from VoiceType to Yap across all source files, config paths, and docs
- Bundle ID: `com.yap.app`
- Config path: `~/.config/yap/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)