### PR TITLE
feat: double-tap hands-free recording, HID hotkey, and UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
+.build/
+.swiftpm/
 .DS_Store
 *.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ cp -r build/Yap.app /Applications/            # Install
 open /Applications/Yap.app                    # Run
 ```
 
-No package manager or Xcode project — just `swiftc` compiling all `Sources/*.swift` directly. Requires macOS 12+ and Xcode Command Line Tools.
+Uses Swift Package Manager (`Package.swift`) for compilation and dependency management. `build.sh` runs `swift build` then assembles the `.app` bundle. Requires macOS 13+ and Xcode Command Line Tools. Open `Package.swift` in Xcode for full IDE support (previews, debugging, breakpoints).
 
 **Runtime permissions**: Microphone, Speech Recognition, and Accessibility (System Settings → Privacy & Security). The app won't function without these.
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -20,7 +20,7 @@ func log(_ message: String) {
 }
 
 enum AppState {
-    case idle, recording, processing
+    case idle, recording, handsFreeRecording, handsFreePaused, processing
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
@@ -36,6 +36,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     private var isEnabled = true
     private var enableMenuItem: NSMenuItem!
     private var peakAudioLevel: Float = 0
+    private var handsFreeEntryTime: Date?
+    private var shortTapCleanupWork: DispatchWorkItem?
     private var chimeWorkItem: DispatchWorkItem?
     private var onboardingHoldWork: DispatchWorkItem?
     private var soundPlayers: [String: AVAudioPlayer] = [:]
@@ -113,7 +115,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             } else {
                 button.image = NSImage(systemSymbolName: "mic", accessibilityDescription: "Yap")
             }
-        case .recording:
+        case .recording, .handsFreeRecording, .handsFreePaused:
             button.image = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: "Yap")
         case .processing:
             button.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: "Yap")
@@ -197,6 +199,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             onKeyDown: { [weak self] in self?.startRecording() },
             onKeyUp: { [weak self] in self?.stopAndTranscribe() }
         )
+        hotkeyManager.onDoubleTap = { [weak self] in self?.startHandsFreeRecording() }
         
         let started = hotkeyManager.start()
         log("Hotkey (\(hotkeyType)): \(started ? "✅" : "❌ — no Accessibility?")")
@@ -314,7 +317,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         if let step = overlayPanel.currentOnboardingStep {
             switch step {
             case .speakTip, .holdTip:
-                overlayPanel.advanceOnboarding(to: .tryIt)
+                if UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) {
+                    overlayPanel.completeOnboarding()
+                } else {
+                    overlayPanel.advanceOnboarding(to: .tryIt)
+                }
             default:
                 break
             }
@@ -369,22 +376,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             return
         }
 
+        // In hands-free mode, fn release stops recording (ignore the entry release)
+        if state == .handsFreeRecording || state == .handsFreePaused {
+            if let entry = handsFreeEntryTime, Date().timeIntervalSince(entry) < 0.5 {
+                handsFreeEntryTime = nil
+                return
+            }
+            stopHandsFreeRecording()
+            return
+        }
+
         guard state == .recording else { return }
-        
+
         let duration = Date().timeIntervalSince(recordingStart ?? Date())
         log("Duration: \(String(format: "%.1f", duration))s, peak: \(peakAudioLevel)")
-        
+
         // Too short = accidental tap
         guard duration >= 1.2 else {
             // Keep pill expanded and mic running for a smooth minimum duration
             let remaining = max(0.5, 1.0 - duration)
-            DispatchQueue.main.asyncAfter(deadline: .now() + remaining) { [weak self] in
+            let work = DispatchWorkItem { [weak self] in
                 guard let self, self.state == .recording else { return }
+                self.shortTapCleanupWork = nil
                 self.audioRecorder.cancel()
                 self.chimeWorkItem = nil
                 self.playSound("Pop")
                 self.showTip(.holdTip)
             }
+            shortTapCleanupWork = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + remaining, execute: work)
             return
         }
 
@@ -400,14 +420,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             return
         }
         playSound("Pop")
-        
+
+        processRecordedAudio(audioURL: audioURL)
+    }
+
+    /// Shared audio processing pipeline used by both hold-to-record and hands-free modes
+    private func processRecordedAudio(audioURL: URL) {
         // Silence check — levels are RMS * 5, so 0.15 ≈ actual quiet speech threshold
         if peakAudioLevel < 0.15 {
             log("Silence detected (peak \(peakAudioLevel)) — skipping")
             showTip(.speakTip)
             return
         }
-        
+
         // Determine flow based on configured engines
         if let apiTranscriber = audioTranscriber {
             // Quick Apple Speech pre-check: if no words detected, skip API call
@@ -420,13 +445,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
                     } else {
                         hasSpeech = false
                     }
-                    
+
                     guard hasSpeech else {
                         log("Pre-check: no speech detected — skipping API call")
                         self?.showTip(.speakTip)
                         return
                     }
-                    
+
                     log("Pre-check: speech detected, proceeding with API")
                     self?.sendToAPI(apiTranscriber: apiTranscriber, audioURL: audioURL)
                 }
@@ -568,6 +593,78 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         updateIcon(.idle)
         overlayPanel.dismiss()
         restoreOnboardingIfNeeded()
+    }
+
+    // MARK: - Hands-Free Recording
+
+    private func startHandsFreeRecording() {
+        log("Double-tap — entering hands-free mode")
+
+        // Cancel pending short-tap cleanup from the first tap
+        shortTapCleanupWork?.cancel()
+        shortTapCleanupWork = nil
+
+        // Must already be recording (from the first tap's onKeyDown)
+        guard state == .recording else { return }
+
+        // Don't allow hands-free during onboarding
+        guard UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) else { return }
+
+        state = .handsFreeRecording
+        handsFreeEntryTime = Date()
+
+        overlayPanel.showHandsFreeRecording(
+            onPauseResume: { [weak self] in self?.toggleHandsFreePause() },
+            onStop: { [weak self] in self?.stopHandsFreeRecording() }
+        )
+    }
+
+    private func toggleHandsFreePause() {
+        if state == .handsFreeRecording {
+            audioRecorder.pause()
+            state = .handsFreePaused
+            overlayPanel.setHandsFreePaused(true)
+            log("Hands-free: paused")
+        } else if state == .handsFreePaused {
+            audioRecorder.resume()
+            state = .handsFreeRecording
+            overlayPanel.setHandsFreePaused(false)
+            log("Hands-free: resumed")
+        }
+    }
+
+    private func stopHandsFreeRecording() {
+        guard state == .handsFreeRecording || state == .handsFreePaused else { return }
+        log("Hands-free: stopping")
+
+        chimeWorkItem = nil
+
+        guard let audioURL = audioRecorder.stop() else {
+            playSound("Pop")
+            state = .idle
+            updateIcon(.idle)
+            overlayPanel.contractHandsFree()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                self?.overlayPanel.dismiss()
+            }
+            return
+        }
+        playSound("Pop")
+
+        // Check silence before committing to processing UI
+        if peakAudioLevel < 0.15 {
+            log("Silence detected (peak \(peakAudioLevel)) — skipping")
+            overlayPanel.contractHandsFree()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                self?.showTip(.speakTip)
+            }
+            return
+        }
+
+        state = .processing
+        updateIcon(.processing)
+        overlayPanel.showProcessing()
+        processRecordedAudio(audioURL: audioURL)
     }
 
     private func restoreOnboardingIfNeeded() {

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -11,6 +11,9 @@ class AudioRecorder {
     var onLevelUpdate: ((Float) -> Void)?
     var onBandLevels: (([Float]) -> Void)?
 
+    /// When paused, audio data is not written to the file but levels are still computed
+    private(set) var isPaused = false
+
     /// We compute 6 raw frequency bands, then mirror them for the 11-bar display
     private let rawBandCount = 6
 
@@ -34,9 +37,13 @@ class AudioRecorder {
 
         audioFile = try AVAudioFile(forWriting: tempURL, settings: settings)
 
+        isPaused = false
+
         engine.inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat) { [weak self] buffer, _ in
             guard let self = self else { return }
-            try? self.audioFile?.write(from: buffer)
+            if !self.isPaused {
+                try? self.audioFile?.write(from: buffer)
+            }
 
             guard let channelData = buffer.floatChannelData?[0] else { return }
             let frames = Int(buffer.frameLength)
@@ -67,6 +74,7 @@ class AudioRecorder {
         engine?.stop()
         engine = nil
         audioFile = nil
+        isPaused = false
         return FileManager.default.fileExists(atPath: tempURL.path) ? tempURL : nil
     }
 
@@ -76,6 +84,17 @@ class AudioRecorder {
         engine?.stop()
         engine = nil
         audioFile = nil
+        isPaused = false
+    }
+
+    /// Pause recording — audio data is not written but the engine stays running for level updates.
+    func pause() {
+        isPaused = true
+    }
+
+    /// Resume recording — audio data is written again, seamlessly stitching with prior audio.
+    func resume() {
+        isPaused = false
     }
     
     /// Compute frequency band levels using FFT via Accelerate

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -5,47 +5,70 @@ import Cocoa
 class HotkeyManager {
     var onKeyDown: () -> Void
     var onKeyUp: () -> Void
-    
+    var onDoubleTap: (() -> Void)?
+
     private let modifierMask: CGEventFlags
     private var eventTap: CFMachPort?
     private(set) var isHeld = false
-    
+    private var lastKeyUpTime: Date?
+    private let doubleTapWindow: TimeInterval = 0.35
+    /// Whether we're monitoring the fn/Globe key (vs Option, etc.)
+    private let isFnKey: Bool
+
     init(modifierMask: UInt64, onKeyDown: @escaping () -> Void, onKeyUp: @escaping () -> Void) {
         self.modifierMask = CGEventFlags(rawValue: modifierMask)
+        self.isFnKey = modifierMask == 0x00800000
         self.onKeyDown = onKeyDown
         self.onKeyUp = onKeyUp
     }
-    
+
     /// Start the event tap. Returns false if accessibility permission is missing.
     func start() -> Bool {
+        // Intercept flagsChanged + keyDown/keyUp (to suppress fn/Globe emoji picker)
         let mask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
+            | (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.keyUp.rawValue)
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
-        
-        guard let tap = CGEvent.tapCreate(
+
+        // Try HID-level tap first — intercepts before the emoji picker sees events.
+        // Falls back to session-level tap if HID tap isn't available.
+        let tap: CFMachPort
+        if let hidTap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: hotkeyCallback,
+            userInfo: selfPtr
+        ) {
+            tap = hidTap
+        } else if let sessionTap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: mask,
             callback: hotkeyCallback,
             userInfo: selfPtr
-        ) else {
+        ) {
+            tap = sessionTap
+        } else {
             return false
         }
-        
+
         eventTap = tap
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
         return true
     }
-    
+
     func stop() {
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
             eventTap = nil
         }
     }
-    
+
     fileprivate func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         // Re-enable if system disabled the tap
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
@@ -54,29 +77,48 @@ class HotkeyManager {
             }
             return Unmanaged.passUnretained(event)
         }
-        
+
+        // Suppress fn/Globe keyDown/keyUp that trigger the emoji picker.
+        // Always consume keycode 63/179 when fn is our hotkey — don't wait for isHeld,
+        // since the keyDown may arrive before the flagsChanged event.
+        if type == .keyDown || type == .keyUp {
+            if isFnKey {
+                let keycode = event.getIntegerValueField(.keyboardEventKeycode)
+                if keycode == 63 || keycode == 179 {
+                    return nil
+                }
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
         guard type == .flagsChanged else {
             return Unmanaged.passUnretained(event)
         }
-        
+
         let flags = event.flags
         let triggerActive = flags.contains(modifierMask)
-        
+
         // Only trigger if no other modifiers are held (don't steal fn+arrows, option+letter, etc.)
         let otherModifiers: CGEventFlags = [.maskShift, .maskControl, .maskAlternate, .maskCommand]
         let relevantOthers = flags.intersection(otherModifiers).subtracting(modifierMask)
         let hasOtherModifiers = !relevantOthers.isEmpty
-        
+
         if triggerActive && !hasOtherModifiers && !isHeld {
             isHeld = true
-            DispatchQueue.main.async { self.onKeyDown() }
+            if let lastUp = lastKeyUpTime, Date().timeIntervalSince(lastUp) < doubleTapWindow {
+                lastKeyUpTime = nil
+                DispatchQueue.main.async { self.onDoubleTap?() }
+            } else {
+                DispatchQueue.main.async { self.onKeyDown() }
+            }
             return nil // consume event (suppress system fn/option behavior)
         } else if !triggerActive && isHeld {
             isHeld = false
+            lastKeyUpTime = Date()
             DispatchQueue.main.async { self.onKeyUp() }
             return nil // consume release too
         }
-        
+
         return Unmanaged.passUnretained(event)
     }
 }

--- a/Sources/OverlayPanel.swift
+++ b/Sources/OverlayPanel.swift
@@ -1,15 +1,21 @@
 import Cocoa
 import SwiftUI
 
+/// NSHostingView subclass that accepts the first mouse click even when the window isn't key.
+/// Fixes the "double-click to activate" issue on NSPanel.
+class ClickThroughHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
+
 /// A floating pill-shaped overlay at the bottom of the screen
 /// with audio-reactive waveform bars and a processing spinner.
 class OverlayPanel: NSPanel {
     private let overlayState = OverlayState()
     private var errorDismissWork: DispatchWorkItem?
 
-    override var canBecomeKey: Bool { false }
+    override var canBecomeKey: Bool { overlayState.isHandsFree }
     override var canBecomeMain: Bool { false }
-    
+
     init() {
         let width: CGFloat = 1400
         let height: CGFloat = 700
@@ -17,14 +23,14 @@ class OverlayPanel: NSPanel {
         let screenFrame = NSScreen.main?.frame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let x = screenFrame.midX - width / 2
         let y = screenFrame.minY + 330 - height
-        
+
         super.init(
             contentRect: NSRect(x: x, y: y, width: width, height: height),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
-        
+
         level = .floating
         isOpaque = false
         backgroundColor = .clear
@@ -33,8 +39,8 @@ class OverlayPanel: NSPanel {
         isMovableByWindowBackground = false
         hidesOnDeactivate = false
         ignoresMouseEvents = true // clicks pass through entirely
-        
-        let hostingView = NSHostingView(rootView:
+
+        let hostingView = ClickThroughHostingView(rootView:
             OverlayView(state: overlayState)
                 .frame(width: width, height: height)
         )
@@ -52,6 +58,21 @@ class OverlayPanel: NSPanel {
         }
     }
 
+    func showHandsFreeRecording(onPauseResume: @escaping () -> Void, onStop: @escaping () -> Void) {
+        overlayState.onPauseResume = onPauseResume
+        overlayState.onStop = onStop
+        overlayState.isPaused = false
+        overlayState.onboardingStep = nil
+        ignoresMouseEvents = false
+        overlayState.isHandsFree = true
+    }
+
+    func setHandsFreePaused(_ paused: Bool) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            overlayState.isPaused = paused
+        }
+    }
+
     func updateLevel(_ level: Float) {
         overlayState.audioLevel = level
     }
@@ -60,7 +81,21 @@ class OverlayPanel: NSPanel {
         overlayState.bandLevels = levels
     }
 
+    /// Contract the hands-free UI (buttons fly back, pill shrinks) without changing mode.
+    func contractHandsFree() {
+        ignoresMouseEvents = true
+        overlayState.isHandsFree = false
+        overlayState.isPaused = false
+        overlayState.onPauseResume = nil
+        overlayState.onStop = nil
+    }
+
     func showProcessing() {
+        ignoresMouseEvents = true
+        overlayState.isHandsFree = false
+        overlayState.isPaused = false
+        overlayState.onPauseResume = nil
+        overlayState.onStop = nil
         overlayState.mode = .processing
     }
 
@@ -75,6 +110,11 @@ class OverlayPanel: NSPanel {
     }
 
     func dismiss() {
+        ignoresMouseEvents = true
+        overlayState.isHandsFree = false
+        overlayState.isPaused = false
+        overlayState.onPauseResume = nil
+        overlayState.onStop = nil
         withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: 0.35)) {
             overlayState.mode = .idle
         }
@@ -165,6 +205,10 @@ class OverlayState: ObservableObject {
     @Published var hotkeyLabel: String = "fn"
     @Published var shakeToken: UUID = UUID()
     @Published var isPressed: Bool = false
+    @Published var isHandsFree: Bool = false
+    @Published var isPaused: Bool = false
+    var onPauseResume: (() -> Void)?
+    var onStop: (() -> Void)?
     var isOnboarding: Bool { onboardingStep != nil }
 }
 
@@ -214,7 +258,7 @@ struct OverlayView: View {
                 }
                 .fixedSize()
                 .frame(minWidth: 40, minHeight: isExpanded ? 28 : 8)
-                .padding(.horizontal, 12)
+                .padding(.horizontal, state.isHandsFree ? 7 : 12)
                 .padding(.vertical, 6)
                 .background(
                     ZStack {
@@ -229,13 +273,15 @@ struct OverlayView: View {
                     Capsule()
                         .strokeBorder(Color.white.opacity(isExpanded ? 0.3 : 0.35), lineWidth: isExpanded ? 1 : 1.5)
                 )
-                .scaleEffect((isExpanded ? 1.0 : 0.5) * audioBounceFactor * (state.isPressed ? 0.85 : 1.0))
+                .scaleEffect((isExpanded ? 1.0 : 0.5) * audioBounceFactor * (state.isPressed ? 0.85 : 1.0) * (state.mode == .processing ? 0.8 : 1.0))
                 .opacity(state.isPressed ? 0.7 : 1.0)
                 .offset(y: isExpanded ? 0 : 40)
                 .modifier(ShakeEffect(progress: shakeProgress))
                 .animation(.spring(response: 0.25, dampingFraction: 0.45, blendDuration: 0.05), value: state.audioLevel)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: state.onboardingStep)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: state.mode)
+                .animation(.spring(response: 0.35, dampingFraction: 0.8), value: state.isHandsFree)
+                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: state.isPaused)
                 .overlay(alignment: .bottom) {
                     if let step = state.onboardingStep,
                        state.mode == .idle || state.mode == .noSpeech {
@@ -282,9 +328,49 @@ struct OverlayView: View {
         } else {
             switch state.mode {
             case .recording, .processing:
-                WaveformBars(level: CGFloat(state.audioLevel), bandLevels: state.bandLevels, isProcessing: state.mode == .processing)
-                    .frame(width: 52, height: 28)
-                    .transition(.opacity)
+                ZStack {
+                    // Single unified bar view — no view swap between recording and processing
+                    BarVisualizer(bandLevels: state.bandLevels, isProcessing: state.mode == .processing)
+                        .frame(width: 52, height: 28)
+                        .opacity(state.isHandsFree && state.isPaused ? 0 : 1)
+
+                    // Paused overlay
+                    if state.isHandsFree && state.isPaused {
+                        HStack(spacing: 2) {
+                            ForEach(0..<11, id: \.self) { _ in
+                                RoundedRectangle(cornerRadius: 1.5)
+                                    .fill(Color.white.opacity(0.25))
+                                    .frame(width: 3, height: 5)
+                            }
+                        }
+                        .frame(width: 52, height: 28)
+                    }
+
+                    // Buttons — always present, visibility controlled by isHandsFree
+                    Image(systemName: state.isPaused ? "play.fill" : "pause.fill")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.9))
+                        .frame(width: 26, height: 26)
+                        .background(Circle().fill(Color.white.opacity(0.15)))
+                        .contentShape(Circle())
+                        .onTapGesture { state.onPauseResume?() }
+                        .offset(x: state.isHandsFree ? -49 : 0)
+                        .scaleEffect(state.isHandsFree ? 1 : 0.001)
+                        .opacity(state.isHandsFree ? 1 : 0)
+
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(width: 26, height: 26)
+                        .background(Circle().fill(Color.red.opacity(0.85)))
+                        .contentShape(Circle())
+                        .onTapGesture { state.onStop?() }
+                        .offset(x: state.isHandsFree ? 49 : 0)
+                        .scaleEffect(state.isHandsFree ? 1 : 0.001)
+                        .opacity(state.isHandsFree ? 1 : 0)
+                }
+                .frame(width: state.isHandsFree ? 124 : 52, height: 28)
+                .transition(.opacity)
             case .noSpeech:
                 HStack(spacing: 2) {
                     ForEach(0..<11, id: \.self) { _ in
@@ -434,118 +520,88 @@ struct OnboardingCardView: View {
 
 // MARK: - Waveform
 
-struct WaveformBars: View {
-    var level: CGFloat
+// MARK: - Unified bar visualizer (recording + processing in one view)
+struct BarVisualizer: View {
     var bandLevels: [Float]
     var isProcessing: Bool
     let barCount = 11
-    
-    var body: some View {
-        if isProcessing {
-            WaveAnimationBars(lastLevel: level, barCount: barCount)
-        } else {
-            AudioReactiveBars(bandLevels: bandLevels, barCount: barCount)
-        }
-    }
-}
 
-// MARK: - Recording: lightweight, no TimelineView
-struct AudioReactiveBars: View {
-    var bandLevels: [Float]
-    let barCount: Int
-    
     // Position scaling — center emphasis, edges still move
     private let positionScale: [CGFloat] = [0.35, 0.45, 0.6, 0.78, 0.92, 1.0, 0.94, 0.8, 0.63, 0.48, 0.38]
-    
-    var body: some View {
-        HStack(spacing: 2) {
-            ForEach(0..<barCount, id: \.self) { index in
-                let bandLevel = index < bandLevels.count ? CGFloat(bandLevels[index]) : 0
-                // FFT variation: offset each bar's level by its band data
-                let bandOffset = index < bandLevels.count ? CGFloat(bandLevels[index]) : 0
-                // Blend: 70% overall volume + 30% per-band FFT variation
-                let overall = bandLevels.isEmpty ? bandLevel : CGFloat(bandLevels.reduce(Float(0), +) / Float(bandLevels.count))
-                let blended = overall * 0.7 + bandOffset * 0.3
-                
-                let scale = positionScale[index]
-                
-                let minH: CGFloat = 5
-                let maxH: CGFloat = 28
-                let barCeiling = minH + (maxH - minH) * scale
-                
-                // Scale so bars max out at ~75% volume, clamp at 1.0
-                let scaled = min(blended / 0.75, 1.0)
-                let driven = pow(scaled, 0.6)
-                let barHeight = max(minH, min(barCeiling, minH + (barCeiling - minH) * driven))
-                
-                RoundedRectangle(cornerRadius: 1.5)
-                    .fill(Color.white.opacity(0.9))
-                    .frame(width: 3, height: barHeight)
-                    .animation(.easeOut(duration: 0.1), value: blended)
-            }
-        }
-    }
-}
 
-// MARK: - Processing: TimelineView for wave animation
-struct WaveAnimationBars: View {
-    let lastLevel: CGFloat
-    let barCount: Int
-    
-    @State private var displayLevel: CGFloat = 1
+    @State private var appeared = false
     @State private var waveStrength: CGFloat = 0
-    @State private var startTime: Date? = nil
-    
+    @State private var audioDecay: CGFloat = 1
+    @State private var waveStart: Date? = nil
+    @State private var wasProcessing = false
+
     var body: some View {
-        TimelineView(.animation) { timeline in
-            let elapsed = startTime.map { timeline.date.timeIntervalSince($0) } ?? 0
-            // Sweep from well off-left to well off-right so the wave
-            // fully exits before looping. With gaussian width 6.0,
-            // need ~5 units of margin for the tail to fully disappear.
+        TimelineView(.animation(paused: !isProcessing)) { timeline in
+            let elapsed = waveStart.map { timeline.date.timeIntervalSince($0) } ?? 0
             let margin = 5.0
             let sweepRange = Double(barCount - 1) + margin * 2
             let t = elapsed.truncatingRemainder(dividingBy: 1.2) / 1.2
             let waveCenter = -margin + t * sweepRange
-            
-            HStack(spacing: 2) {
+
+            HStack(alignment: .center, spacing: 2) {
                 ForEach(0..<barCount, id: \.self) { index in
-                    // Audio-reactive base (decaying via displayLevel)
-                    let center = CGFloat(barCount - 1) / 2.0
-                    let distFromCenter = abs(CGFloat(index) - center) / center
-                    let positionScale = 1.0 - (distFromCenter * 0.5)
-                    let boosted = pow(lastLevel * displayLevel, 0.5)
-                    let audioH = max(6.0, min(28.0, 6.0 + 22.0 * boosted * positionScale))
-                    
-                    // Wave overlay — very wide and gentle rolling wave
+                    let scale = positionScale[index]
+                    let minH: CGFloat = 5
+                    let maxH: CGFloat = 28
+
+                    // Audio-reactive height (decays when processing)
+                    let bandLevel = index < bandLevels.count ? CGFloat(bandLevels[index]) : 0
+                    let bandOffset = index < bandLevels.count ? CGFloat(bandLevels[index]) : 0
+                    let overall = bandLevels.isEmpty ? bandLevel : CGFloat(bandLevels.reduce(Float(0), +) / Float(bandLevels.count))
+                    let blended = (overall * 0.7 + bandOffset * 0.3) * audioDecay
+                    let barCeiling = minH + (maxH - minH) * scale
+                    let scaled = min(blended / 0.75, 1.0)
+                    let driven = pow(scaled, 0.6)
+                    let audioH = max(minH, min(barCeiling, minH + (barCeiling - minH) * driven))
+
+                    // Wave overlay (fades in during processing)
                     let distance = abs(Double(index) - waveCenter)
                     let wave = exp(-distance * distance / 6.0)
                     let waveH = 14.0 * CGFloat(wave) * waveStrength
-                    
-                    let barHeight = min(28.0, max(6.0, audioH + waveH))
-                    
-                    // Shimmer: opacity pulses with the wave — bright at peak, dim at rest
+
+                    let barHeight = min(28.0, max(minH, audioH + waveH))
+
+                    // Shimmer during processing
                     let dimOpacity = 0.35
                     let brightOpacity = 0.95
                     let shimmer = dimOpacity + (brightOpacity - dimOpacity) * Double(wave) * Double(waveStrength)
-                    // When wave hasn't faded in yet, keep full opacity
-                    let opacity = waveStrength > 0 ? shimmer : 0.9
-                    
+                    let barOpacity = waveStrength > 0.01 ? shimmer : 0.9
+
                     RoundedRectangle(cornerRadius: 1.5)
-                        .fill(Color.white.opacity(opacity))
+                        .fill(Color.white.opacity(barOpacity))
                         .frame(width: 3, height: barHeight)
                 }
             }
         }
+        .frame(height: 28)
+        .scaleEffect(x: appeared ? 1 : 0.001, y: 1, anchor: .center)
+        .opacity(appeared ? 1 : 0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.75), value: appeared)
         .onAppear {
-            startTime = Date()
-            displayLevel = 1
-            waveStrength = 0
-            withAnimation(.easeOut(duration: 0.35)) {
-                displayLevel = 0
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                appeared = true
             }
-            withAnimation(.easeIn(duration: 0.35).delay(0.15)) {
-                waveStrength = 1
+        }
+        .onChange(of: isProcessing) { processing in
+            if processing && !wasProcessing {
+                waveStart = Date()
+                withAnimation(.easeOut(duration: 0.35)) {
+                    audioDecay = 0
+                }
+                withAnimation(.easeIn(duration: 0.35).delay(0.15)) {
+                    waveStrength = 1
+                }
+            } else if !processing {
+                audioDecay = 1
+                waveStrength = 0
+                waveStart = nil
             }
+            wasProcessing = processing
         }
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -5,22 +5,18 @@ APP_NAME="Yap"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 
-echo "🔨 Building $APP_NAME..."
+echo "Building $APP_NAME..."
 
-# Clean previous build
+# Clean previous app bundle
 rm -rf "$BUILD_DIR"
 mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 
-# Compile all Swift sources
-swiftc \
-    -o "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
-    Sources/*.swift \
-    -framework Cocoa \
-    -framework AVFoundation \
-    -framework Speech \
-    -O \
-    -suppress-warnings
+# Build with Swift Package Manager (incremental)
+swift build -c release --quiet 2>&1 | grep -v "warning:" || true
+
+# Copy binary into app bundle
+cp .build/release/Yap "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
 # Copy Info.plist
 cp Resources/Info.plist "$APP_BUNDLE/Contents/"
@@ -47,14 +43,14 @@ if [ -f Resources/AppIcon.png ]; then
     sips -z 1024 1024 Resources/AppIcon.png --out "$ICONSET/icon_512x512@2x.png" > /dev/null 2>&1
     iconutil -c icns "$ICONSET" -o "$APP_BUNDLE/Contents/Resources/AppIcon.icns"
     rm -rf "$ICONSET"
-    echo "🎨 App icon generated"
+    echo "App icon generated"
 fi
 
 # Ad-hoc code sign
 codesign --force --sign - "$APP_BUNDLE"
 
 echo ""
-echo "✅ Built: $APP_BUNDLE"
+echo "Built: $APP_BUNDLE"
 echo ""
 echo "To install:"
 echo "  cp -r $APP_BUNDLE /Applications/"
@@ -63,4 +59,4 @@ echo "To run:"
 echo "  open /Applications/$APP_NAME.app"
 echo ""
 echo "First run: grant Microphone, Speech Recognition, and Accessibility"
-echo "in System Settings → Privacy & Security."
+echo "in System Settings > Privacy & Security."


### PR DESCRIPTION
## Summary
- **Double-tap hotkey for hands-free recording** — tap fn/Globe twice quickly to start hands-free mode (closes #12)
- **HID-level event tap** — intercepts hotkey before the emoji picker, falling back to session-level if unavailable
- **Audio recorder improvements** — FFT and recording pipeline updates
- **Overlay panel UI refinements** — updated animations and processing state visuals
- **Build script updates** — migrated to Swift Package Manager

## Test plan
- [ ] Double-tap fn to enter hands-free recording mode
- [ ] Single hold fn still works for press-to-record
- [ ] Emoji picker no longer triggers during hotkey use
- [ ] Overlay animations display correctly during recording and processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)