### PR TITLE
feat: Groq provider, provider settings UI, and UX fixes

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -391,10 +391,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         let duration = Date().timeIntervalSince(recordingStart ?? Date())
         log("Duration: \(String(format: "%.1f", duration))s, peak: \(peakAudioLevel)")
 
-        // Too short = accidental tap
-        guard duration >= 1.2 else {
-            // Keep pill expanded and mic running for a smooth minimum duration
-            let remaining = max(0.5, 1.0 - duration)
+        // Too short = accidental tap (but if speech was detected, let it through)
+        guard duration >= 0.5 || peakAudioLevel >= 0.15 else {
+            // Show the hold tip quickly after a short tap
+            let remaining = max(0.15, 0.4 - duration)
             let work = DispatchWorkItem { [weak self] in
                 guard let self, self.state == .recording else { return }
                 self.shortTapCleanupWork = nil

--- a/Sources/OverlayPanel.swift
+++ b/Sources/OverlayPanel.swift
@@ -233,7 +233,7 @@ struct OverlayView: View {
     }
 
     private var audioBounceFactor: CGFloat {
-        guard state.mode == .recording else { return 1.0 }
+        guard state.mode == .recording, !state.isPaused else { return 1.0 }
         let level = min(CGFloat(state.audioLevel), 1.0)
         return 1.0 + pow(level, 1.5) * 0.25
     }
@@ -537,7 +537,7 @@ struct BarVisualizer: View {
 
     var body: some View {
         TimelineView(.animation(paused: !isProcessing)) { timeline in
-            let elapsed = waveStart.map { timeline.date.timeIntervalSince($0) } ?? 0
+            let elapsed = (isProcessing && waveStart != nil) ? timeline.date.timeIntervalSince(waveStart!) : 0.0
             let margin = 5.0
             let sweepRange = Double(barCount - 1) + margin * 2
             let t = elapsed.truncatingRemainder(dividingBy: 1.2) / 1.2
@@ -566,15 +566,16 @@ struct BarVisualizer: View {
 
                     let barHeight = min(28.0, max(minH, audioH + waveH))
 
-                    // Shimmer during processing
+                    // Shimmer during processing — bright at wave peak, dim at edges
                     let dimOpacity = 0.35
                     let brightOpacity = 0.95
                     let shimmer = dimOpacity + (brightOpacity - dimOpacity) * Double(wave) * Double(waveStrength)
-                    let barOpacity = waveStrength > 0.01 ? shimmer : 0.9
+                    let barOpacity = isProcessing ? shimmer : 0.9
 
                     RoundedRectangle(cornerRadius: 1.5)
                         .fill(Color.white.opacity(barOpacity))
                         .frame(width: 3, height: barHeight)
+                        .animation(.interpolatingSpring(stiffness: 280, damping: 18), value: bandLevel)
                 }
             }
         }
@@ -588,7 +589,7 @@ struct BarVisualizer: View {
             }
         }
         .onChange(of: isProcessing) { processing in
-            if processing && !wasProcessing {
+            if processing {
                 waveStart = Date()
                 withAnimation(.easeOut(duration: 0.35)) {
                     audioDecay = 0
@@ -596,12 +597,11 @@ struct BarVisualizer: View {
                 withAnimation(.easeIn(duration: 0.35).delay(0.15)) {
                     waveStrength = 1
                 }
-            } else if !processing {
+            } else {
+                waveStart = nil
                 audioDecay = 1
                 waveStrength = 0
-                waveStart = nil
             }
-            wasProcessing = processing
         }
     }
 }

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -17,6 +17,63 @@ enum SettingsKey {
     static let fmtModel = "fmtModel"
     static let fmtStyle = "fmtStyle"
     static let onboardingComplete = "onboardingComplete"
+
+    // Deepgram options
+    static let dgSmartFormat = "dgSmartFormat"
+    static let dgKeywords = "dgKeywords"
+    static let dgLanguage = "dgLanguage"
+
+    // OpenAI transcription options
+    static let oaiLanguage = "oaiLanguage"
+    static let oaiPrompt = "oaiPrompt"
+
+    // Gemini transcription options
+    static let geminiTemperature = "geminiTemperature"
+
+    // ElevenLabs options
+    static let elLanguageCode = "elLanguageCode"
+}
+
+// MARK: - Reusable Components
+
+/// Inline description shown below a setting — visible without hovering
+private struct SettingDescription: View {
+    let text: String
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// A toggle with an inline description underneath
+private struct DescribedToggle: View {
+    let title: String
+    let description: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Toggle(title, isOn: $isOn)
+            SettingDescription(text: description)
+        }
+    }
+}
+
+/// A text field with an inline description underneath
+private struct DescribedTextField: View {
+    let title: String
+    let description: String
+    let placeholder: String
+    @Binding var text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            TextField(title, text: $text, prompt: Text(placeholder))
+            SettingDescription(text: description)
+        }
+    }
 }
 
 // MARK: - SwiftUI Settings View
@@ -36,6 +93,21 @@ struct SettingsView: View {
     @State private var fmtStyle: String
     @State private var fmtUseSameKey: Bool
 
+    // Deepgram options
+    @State private var dgSmartFormat: Bool
+    @State private var dgKeywords: String
+    @State private var dgLanguage: String
+
+    // OpenAI transcription options
+    @State private var oaiLanguage: String
+    @State private var oaiPrompt: String
+
+    // Gemini options
+    @State private var geminiTemperature: Double
+
+    // ElevenLabs options
+    @State private var elLanguageCode: String
+
     var onSave: (() -> Void)?
     var onCancel: (() -> Void)?
 
@@ -53,6 +125,17 @@ struct SettingsView: View {
         let txKey = d.string(forKey: SettingsKey.txApiKey) ?? ""
         let fKey = d.string(forKey: SettingsKey.fmtApiKey) ?? ""
         _fmtUseSameKey = State(initialValue: fKey.isEmpty || fKey == txKey)
+
+        _dgSmartFormat = State(initialValue: d.object(forKey: SettingsKey.dgSmartFormat) as? Bool ?? true)
+        _dgKeywords = State(initialValue: d.string(forKey: SettingsKey.dgKeywords) ?? "")
+        _dgLanguage = State(initialValue: d.string(forKey: SettingsKey.dgLanguage) ?? "")
+
+        _oaiLanguage = State(initialValue: d.string(forKey: SettingsKey.oaiLanguage) ?? "")
+        _oaiPrompt = State(initialValue: d.string(forKey: SettingsKey.oaiPrompt) ?? "")
+
+        _geminiTemperature = State(initialValue: d.object(forKey: SettingsKey.geminiTemperature) as? Double ?? 0.0)
+
+        _elLanguageCode = State(initialValue: d.string(forKey: SettingsKey.elLanguageCode) ?? "")
     }
 
     private var selectedTxProvider: TranscriptionProvider {
@@ -70,96 +153,244 @@ struct SettingsView: View {
     private var hasTxProvider: Bool { selectedTxProvider != .none }
     private var hasFmtProvider: Bool { selectedFmtProvider != .none }
 
+    /// Whether the transcription and formatting providers share the same API backend
+    private var canShareApiKey: Bool {
+        guard hasTxProvider, hasFmtProvider else { return false }
+        switch (selectedTxProvider, selectedFmtProvider) {
+        case (.gemini, .gemini), (.openai, .openai):
+            return true
+        default:
+            return false
+        }
+    }
+
+    // MARK: - Provider Option Views
+
+    private var deepgramOptions: some View {
+        Group {
+            DescribedToggle(
+                title: "Smart Format",
+                description: "Auto-formats numbers, dates, currencies, and adds punctuation",
+                isOn: $dgSmartFormat
+            )
+            DescribedTextField(
+                title: "Language",
+                description: "ISO 639-1 language code (e.g. en, es, fr, ja). Leave empty to auto-detect.",
+                placeholder: "Auto-detect",
+                text: $dgLanguage
+            )
+            DescribedTextField(
+                title: "Keywords",
+                description: "Boost recognition of specific words or names, separated by commas",
+                placeholder: "e.g. Kubernetes, Jira, OAuth",
+                text: $dgKeywords
+            )
+        }
+    }
+
+    private var openAIOptions: some View {
+        Group {
+            DescribedTextField(
+                title: "Language",
+                description: "ISO 639-1 language code (e.g. en, es, fr). Improves accuracy and speed.",
+                placeholder: "Auto-detect",
+                text: $oaiLanguage
+            )
+            DescribedTextField(
+                title: "Prompt",
+                description: "Guide the model with context \u{2014} useful for domain-specific terms, names, or jargon it might mishear",
+                placeholder: "e.g. The speaker discusses SwiftUI and Xcode",
+                text: $oaiPrompt
+            )
+        }
+    }
+
+    private var geminiOptions: some View {
+        Group {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text("Temperature")
+                    Slider(value: $geminiTemperature, in: 0...1, step: 0.1)
+                    Text(String(format: "%.1f", geminiTemperature))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .frame(width: 28)
+                }
+                SettingDescription(text: "Controls randomness. 0 = precise and deterministic, 1 = creative and varied. Lower is better for transcription.")
+            }
+        }
+    }
+
+    private var elevenLabsOptions: some View {
+        Group {
+            DescribedTextField(
+                title: "Language",
+                description: "ISO 639-1 language code (e.g. en, es, fr). Leave empty to auto-detect.",
+                placeholder: "Auto-detect",
+                text: $elLanguageCode
+            )
+        }
+    }
+
+    // MARK: - Style Preview Card
+
+    private var stylePreview: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            VStack(alignment: .leading, spacing: 2) {
+                Text(selectedStyle.label)
+                    .font(.caption.weight(.semibold))
+                Text(selectedStyle.description)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 14, alignment: .leading)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(.quaternary.opacity(0.3))
+
+            // Before / After
+            HStack(alignment: .top, spacing: 0) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Before")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.red.opacity(0.7))
+                    Text(FormattingStyle.exampleInput)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("After")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.green.opacity(0.7))
+                    Text(selectedStyle.exampleOutput)
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .background(.quaternary.opacity(0.15))
+        .clipShape(.rect(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.quaternary, lineWidth: 1)
+        )
+        .animation(.easeInOut(duration: 0.15), value: fmtStyle)
+    }
+
+    // MARK: - Body
+
     var body: some View {
         VStack(spacing: 0) {
-            Form {
-                // General
-                Section {
-                    Picker("Hotkey", selection: $hotkey) {
-                        Text("fn / Globe 🌐").tag("fn")
-                        Text("Option ⌥").tag("option")
-                    }
-                    .pickerStyle(.menu)
-                }
-
-                // Transcription
-                Section {
-                    Picker("Provider", selection: $txProvider) {
-                        ForEach(TranscriptionProvider.allCases, id: \.rawValue) { p in
-                            Text(p.label).tag(p.rawValue)
+            ScrollView {
+                Form {
+                    // General
+                    Section {
+                        Picker("Hotkey", selection: $hotkey) {
+                            Text("fn / Globe").tag("fn")
+                            Text("Option").tag("option")
                         }
+                        .pickerStyle(.menu)
                     }
-                    .pickerStyle(.menu)
 
-                    if hasTxProvider {
-                        TextField("API Key", text: $txApiKey, prompt: Text("Required"))
-
-                        TextField("Model", text: $txModel, prompt: Text(selectedTxProvider.defaultModel))
-                    }
-                } header: {
-                    Text("Transcription")
-                } footer: {
-                    if !hasTxProvider {
-                        Text("Using Apple's built-in dictation — free, on-device.")
-                            .font(.caption).foregroundColor(.secondary)
-                    }
-                }
-
-                // Formatting
-                Section {
-                    Picker("Provider", selection: $fmtProvider) {
-                        ForEach(FormattingProvider.allCases, id: \.rawValue) { p in
-                            Text(p.label).tag(p.rawValue)
-                        }
-                    }
-                    .pickerStyle(.menu)
-
-                    if hasFmtProvider {
-                        let shareKey = fmtUseSameKey && hasTxProvider
-                        TextField("API Key", text: shareKey ? $txApiKey : $fmtApiKey, prompt: Text("Required"))
-                            .disabled(shareKey)
-
-                        if hasTxProvider {
-                            Toggle("Use same API key", isOn: $fmtUseSameKey)
-                        }
-
-                        TextField("Model", text: $fmtModel, prompt: Text(selectedFmtProvider.defaultModel))
-
-                        Picker("Style", selection: $fmtStyle) {
-                            ForEach(FormattingStyle.allCases, id: \.rawValue) { s in
-                                Text(s.label).tag(s.rawValue)
+                    // Transcription
+                    Section {
+                        Picker("Provider", selection: $txProvider) {
+                            ForEach(TranscriptionProvider.allCases, id: \.rawValue) { p in
+                                Text(p.label).tag(p.rawValue)
                             }
                         }
                         .pickerStyle(.menu)
 
-                        // Example preview
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("**\(selectedStyle.label)** — \(selectedStyle.description)")
-                                .font(.caption).foregroundColor(.primary)
-                            Divider()
-                            Text("Input:").font(.caption2).foregroundColor(.secondary)
-                            Text("\"\(FormattingStyle.exampleInput)\"")
-                                .font(.caption).foregroundColor(.secondary).italic()
-                            Text("Output:").font(.caption2).foregroundColor(.secondary).padding(.top, 2)
-                            Text("\"\(selectedStyle.exampleOutput)\"")
-                                .font(.caption).foregroundColor(.primary)
+                        if hasTxProvider {
+                            TextField("API Key", text: $txApiKey, prompt: Text("Required"))
+
+                            DescribedTextField(
+                                title: "Model",
+                                description: "Leave empty to use the default (\(selectedTxProvider.defaultModel))",
+                                placeholder: selectedTxProvider.defaultModel,
+                                text: $txModel
+                            )
+
+                            if selectedTxProvider == .deepgram {
+                                deepgramOptions
+                            } else if selectedTxProvider == .openai {
+                                openAIOptions
+                            } else if selectedTxProvider == .gemini {
+                                geminiOptions
+                            } else if selectedTxProvider == .elevenlabs {
+                                elevenLabsOptions
+                            }
                         }
-                        .padding(.vertical, 4)
-                        .animation(.easeInOut(duration: 0.15), value: fmtStyle)
+                    } header: {
+                        Text("Transcription")
+                    } footer: {
+                        if !hasTxProvider {
+                            Text("Using Apple's built-in dictation \u{2014} free, on-device, no API key needed.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
-                } header: {
-                    Text("Formatting")
-                } footer: {
-                    if !hasFmtProvider {
-                        Text("No formatting — raw transcription will be pasted as-is.")
-                            .font(.caption).foregroundColor(.secondary)
+
+                    // Formatting
+                    Section {
+                        Picker("Provider", selection: $fmtProvider) {
+                            ForEach(FormattingProvider.allCases, id: \.rawValue) { p in
+                                Text(p.label).tag(p.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+
+                        if hasFmtProvider {
+                            let shareKey = fmtUseSameKey && canShareApiKey
+                            TextField("API Key", text: shareKey ? $txApiKey : $fmtApiKey, prompt: Text("Required"))
+                                .disabled(shareKey)
+
+                            if canShareApiKey {
+                                Toggle("Use same API key as transcription", isOn: $fmtUseSameKey)
+                            }
+
+                            DescribedTextField(
+                                title: "Model",
+                                description: "Leave empty to use the default (\(selectedFmtProvider.defaultModel))",
+                                placeholder: selectedFmtProvider.defaultModel,
+                                text: $fmtModel
+                            )
+
+                            Picker("Style", selection: $fmtStyle) {
+                                ForEach(FormattingStyle.allCases, id: \.rawValue) { s in
+                                    Text(s.label).tag(s.rawValue)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+
+                            stylePreview
+                        }
+                    } header: {
+                        Text("Formatting")
+                    } footer: {
+                        if !hasFmtProvider {
+                            Text("No formatting \u{2014} raw transcription will be pasted as-is.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
+                .formStyle(.grouped)
+                .scrollContentBackground(.hidden)
             }
-            .formStyle(.grouped)
-            .scrollContentBackground(.hidden)
             .animation(.easeInOut(duration: 0.2), value: txProvider)
             .animation(.easeInOut(duration: 0.2), value: fmtProvider)
+
+            Divider()
 
             // Buttons
             HStack {
@@ -167,10 +398,15 @@ struct SettingsView: View {
                     UserDefaults.standard.set(false, forKey: SettingsKey.onboardingComplete)
                     onSave?()
                 }
-                .foregroundColor(.secondary)
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+
                 Spacer()
+
                 Button("Cancel") { onCancel?() }
                     .keyboardShortcut(.cancelAction)
+
                 Button("Save") {
                     let d = UserDefaults.standard
                     d.set(hotkey, forKey: SettingsKey.hotkey)
@@ -181,15 +417,30 @@ struct SettingsView: View {
                     d.set(fmtUseSameKey ? "" : fmtApiKey, forKey: SettingsKey.fmtApiKey)
                     d.set(fmtModel, forKey: SettingsKey.fmtModel)
                     d.set(fmtStyle, forKey: SettingsKey.fmtStyle)
+
+                    // Deepgram options
+                    d.set(dgSmartFormat, forKey: SettingsKey.dgSmartFormat)
+                    d.set(dgKeywords, forKey: SettingsKey.dgKeywords)
+                    d.set(dgLanguage, forKey: SettingsKey.dgLanguage)
+
+                    // OpenAI options
+                    d.set(oaiLanguage, forKey: SettingsKey.oaiLanguage)
+                    d.set(oaiPrompt, forKey: SettingsKey.oaiPrompt)
+
+                    // Gemini options
+                    d.set(geminiTemperature, forKey: SettingsKey.geminiTemperature)
+
+                    // ElevenLabs options
+                    d.set(elLanguageCode, forKey: SettingsKey.elLanguageCode)
+
                     onSave?()
                 }
                 .keyboardShortcut(.defaultAction)
             }
             .padding(.horizontal, 20)
-            .padding(.bottom, 16)
-            .padding(.top, 4)
+            .padding(.vertical, 12)
         }
-        .frame(width: 480, height: 600)
+        .frame(width: 500, height: 680)
     }
 }
 
@@ -200,7 +451,7 @@ class SettingsWindow: NSWindow {
 
     init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 600),
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 680),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/TextFormatter.swift
+++ b/Sources/TextFormatter.swift
@@ -171,23 +171,59 @@ enum FormattingProvider: String, CaseIterable {
     case gemini = "gemini"
     case openai = "openai"
     case anthropic = "anthropic"
-    
+    case groq = "groq"
+
     var label: String {
         switch self {
         case .none: return "None"
         case .gemini: return "Google Gemini"
         case .openai: return "OpenAI"
         case .anthropic: return "Anthropic"
+        case .groq: return "Groq"
         }
     }
-    
+
     var defaultModel: String {
         switch self {
         case .none: return ""
         case .gemini: return "gemini-2.5-flash"
         case .openai: return "gpt-4o-mini"
         case .anthropic: return "claude-haiku-4-5-20251001"
+        case .groq: return "llama-3.3-70b-versatile"
         }
+    }
+}
+
+// MARK: - Provider Options
+
+struct TranscriptionOptions {
+    // Deepgram
+    var dgSmartFormat: Bool = true
+    var dgKeywords: [String] = []
+    var dgLanguage: String = ""
+
+    // OpenAI
+    var oaiLanguage: String = ""
+    var oaiPrompt: String = ""
+
+    // Gemini
+    var geminiTemperature: Double = 0.0
+
+    // ElevenLabs
+    var elLanguageCode: String = ""
+
+    static func fromDefaults() -> TranscriptionOptions {
+        let d = UserDefaults.standard
+        var opts = TranscriptionOptions()
+        opts.dgSmartFormat = d.object(forKey: SettingsKey.dgSmartFormat) as? Bool ?? true
+        opts.dgLanguage = d.string(forKey: SettingsKey.dgLanguage) ?? ""
+        let kw = d.string(forKey: SettingsKey.dgKeywords) ?? ""
+        opts.dgKeywords = kw.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        opts.oaiLanguage = d.string(forKey: SettingsKey.oaiLanguage) ?? ""
+        opts.oaiPrompt = d.string(forKey: SettingsKey.oaiPrompt) ?? ""
+        opts.geminiTemperature = d.object(forKey: SettingsKey.geminiTemperature) as? Double ?? 0.0
+        opts.elLanguageCode = d.string(forKey: SettingsKey.elLanguageCode) ?? ""
+        return opts
     }
 }
 
@@ -197,11 +233,13 @@ class AudioTranscriber {
     let provider: TranscriptionProvider
     private let apiKey: String
     private let model: String
-    
-    init(provider: TranscriptionProvider, apiKey: String, model: String? = nil) {
+    let options: TranscriptionOptions
+
+    init(provider: TranscriptionProvider, apiKey: String, model: String? = nil, options: TranscriptionOptions = .fromDefaults()) {
         self.provider = provider
         self.apiKey = apiKey
         self.model = model ?? provider.defaultModel
+        self.options = options
     }
     
     /// Maximum number of retries for transient failures (timeouts, truncated responses)
@@ -297,7 +335,7 @@ class AudioTranscriber {
                     ["text": prompt]
                 ]
             ]],
-            "generationConfig": ["temperature": 0.0, "maxOutputTokens": 2048, "responseMimeType": "application/json"]
+            "generationConfig": ["temperature": options.geminiTemperature, "maxOutputTokens": 2048, "responseMimeType": "application/json"]
         ]
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
@@ -338,14 +376,18 @@ class AudioTranscriber {
             completion(.failure(FormatterError.invalidEndpoint))
             return
         }
-        
+
+        var fields = ["model": model]
+        if !options.oaiLanguage.isEmpty { fields["language"] = options.oaiLanguage }
+        if !options.oaiPrompt.isEmpty { fields["prompt"] = options.oaiPrompt }
+
         let boundary = UUID().uuidString
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = timeout
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.httpBody = multipartBody(boundary: boundary, audioData: audioData, fields: ["model": model])
+        request.httpBody = multipartBody(boundary: boundary, audioData: audioData, fields: fields)
         
         makeRequest(request, label: "OpenAI") { data in
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -364,18 +406,25 @@ class AudioTranscriber {
     // MARK: Deepgram
     
     private func callDeepgram(audioData: Data, timeout: TimeInterval, completion: @escaping (Result<String, Error>) -> Void) {
-        guard let url = URL(string: "https://api.deepgram.com/v1/listen?model=\(model)&smart_format=true&punctuate=true") else {
+        var params = ["model=\(model)"]
+        if options.dgSmartFormat { params.append("smart_format=true") }
+        if !options.dgLanguage.isEmpty { params.append("language=\(options.dgLanguage)") }
+        for kw in options.dgKeywords {
+            params.append("keywords=\(kw.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? kw)")
+        }
+
+        guard let url = URL(string: "https://api.deepgram.com/v1/listen?\(params.joined(separator: "&"))") else {
             completion(.failure(FormatterError.invalidEndpoint))
             return
         }
-        
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = timeout
         request.setValue("Token \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("audio/wav", forHTTPHeaderField: "Content-Type")
         request.httpBody = audioData
-        
+
         makeRequest(request, label: "Deepgram") { data in
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let results = json["results"] as? [String: Any],
@@ -406,8 +455,10 @@ class AudioTranscriber {
         request.timeoutInterval = timeout
         request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.httpBody = multipartBody(boundary: boundary, audioData: audioData, fields: ["model_id": model])
-        
+        var fields = ["model_id": model]
+        if !options.elLanguageCode.isEmpty { fields["language_code"] = options.elLanguageCode }
+        request.httpBody = multipartBody(boundary: boundary, audioData: audioData, fields: fields)
+
         makeRequest(request, label: "ElevenLabs") { data in
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let text = json["text"] as? String {
@@ -520,6 +571,8 @@ class TextFormatter {
             callOpenAI(text: text, completion: completion)
         case .anthropic:
             callAnthropic(text: text, completion: completion)
+        case .groq:
+            callGroq(text: text, completion: completion)
         }
     }
     
@@ -663,8 +716,48 @@ class TextFormatter {
         }.resume()
     }
     
+    // MARK: Groq
+
+    private func callGroq(text: String, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let url = URL(string: "https://api.groq.com/openai/v1/chat/completions") else {
+            completion(.failure(FormatterError.invalidEndpoint))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": style.prompt],
+                ["role": "user", "content": "<input>\(text)</input>"]
+            ],
+            "max_tokens": 2048,
+            "temperature": 0.3
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error { completion(.failure(error)); return }
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]],
+                  let message = choices.first?["message"] as? [String: Any],
+                  let content = message["content"] as? String else {
+                completion(.success(text))
+                return
+            }
+            completion(.success(Self.extractJSON(from: content)))
+        }.resume()
+    }
+
     // MARK: Helpers
-    
+
     static func extractJSON(from text: String) -> String {
         var s = text.trimmingCharacters(in: .whitespacesAndNewlines)
         // Strip markdown code fences


### PR DESCRIPTION
## Summary
- **Groq formatting provider** — ultra-fast LLM formatting via OpenAI-compatible API (`llama-3.3-70b-versatile`)
- **Provider-specific settings** — configurable options for each transcription provider (Deepgram: smart format, language, keywords; OpenAI: language, prompt; Gemini: temperature; ElevenLabs: language)
- **Settings UI redesign** — inline descriptions on every setting, segmented style picker, side-by-side before/after preview card, modern SwiftUI APIs
- **"Use same API key" logic** — only shown when transcription and formatting providers share the same backend
- **Visualizer fixes** — smooth spring animation on bars, fixed processing wave offset/shimmer bug on subsequent uses
- **Recording UX** — lowered short-tap threshold from 1.2s to 0.5s with audio detection fallback, faster hold-tip appearance, pill no longer bounces when paused

## Test plan
- [ ] Select Groq as formatting provider, enter API key, verify formatting works
- [ ] Select each transcription provider and verify its specific options appear
- [ ] Toggle Smart Format on/off with Deepgram, verify behavior changes
- [ ] Switch formatting styles and verify the segmented picker + preview card update smoothly
- [ ] Quick-record "hello" (~0.7s hold) and verify it transcribes instead of showing hold tip
- [ ] Tap fn quickly (<0.3s) and verify hold tip appears fast
- [ ] Start processing and verify wave animation starts from the left, shimmer tracks the peak
- [ ] Do multiple recordings back-to-back and verify wave resets correctly each time
- [ ] Pause during hands-free recording and verify pill stops bouncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)