### PR TITLE
fix: gradient overlay blocks clicks and scrolling

### DIFF
--- a/Sources/OverlayPanel.swift
+++ b/Sources/OverlayPanel.swift
@@ -5,6 +5,13 @@ import SwiftUI
 /// Fixes the "double-click to activate" issue on NSPanel.
 class ClickThroughHostingView<Content: View>: NSHostingView<Content> {
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    /// Let clicks on the gradient background pass through to apps underneath.
+    /// Only interactive subviews (pill buttons) will capture mouse events.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let hit = super.hitTest(point)
+        return hit === self ? nil : hit
+    }
 }
 
 /// A floating pill-shaped overlay at the bottom of the screen
@@ -242,6 +249,7 @@ struct OverlayView: View {
         ZStack {
             if isExpanded {
                 LavaLampBackground(energy: gradientEnergy)
+                    .allowsHitTesting(false)
                     .transition(.opacity)
                     .animation(.easeInOut(duration: 0.8), value: gradientEnergy)
             }


### PR DESCRIPTION
## Summary
- Add `hitTest` override to `ClickThroughHostingView` so clicks on the gradient background pass through to apps underneath
- Mark `LavaLampBackground` with `.allowsHitTesting(false)` in SwiftUI
- Pill and its interactive buttons remain fully clickable

## Test plan
- [ ] Verify scrolling works in apps behind the overlay when gradient is visible
- [ ] Verify clicking through to other apps works when gradient is shown
- [ ] Verify pill buttons (pause/resume, stop) still work in hands-free mode

Closes #17

Generated with [Claude Code](https://claude.com/claude-code)