### PR TITLE
feat: dim background audio while recording

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -29,6 +29,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     private var audioRecorder = AudioRecorder()
     private var transcriber = Transcriber()
     private var pasteManager = PasteManager()
+    private var audioDucker = SystemAudioDucker()
     private lazy var overlayPanel = OverlayPanel()
     private var settingsWindow: SettingsWindow?
     private var state: AppState = .idle
@@ -349,6 +350,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
 
         do {
             try audioRecorder.start()
+            if UserDefaults.standard.bool(forKey: SettingsKey.dimAudio) {
+                audioDucker.duck()
+            }
             // Delay chime so hardware has settled after engine.start()
             let workItem = DispatchWorkItem { [weak self] in
                 self?.playSound("Blow")
@@ -357,6 +361,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
         } catch {
             log("Recording failed: \(error)")
+            audioDucker.restore()
             state = .idle
             updateIcon(.idle)
             overlayPanel.dismiss()
@@ -563,6 +568,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     }
     
     private func showTip(_ step: OnboardingStep) {
+        audioDucker.restore()
         state = .idle
         updateIcon(.idle)
         overlayPanel.showNoSpeech()
@@ -589,6 +595,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     }
 
     private func finishProcessing() {
+        audioDucker.restore()
         state = .idle
         updateIcon(.idle)
         overlayPanel.dismiss()
@@ -640,6 +647,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         chimeWorkItem = nil
 
         guard let audioURL = audioRecorder.stop() else {
+            audioDucker.restore()
             playSound("Pop")
             state = .idle
             updateIcon(.idle)
@@ -688,6 +696,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     
     /// Show a brief error message in the overlay pill, then auto-dismiss
     private func showError(_ error: Error) {
+        audioDucker.restore()
         state = .idle
         updateIcon(.idle)
         

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -32,6 +32,9 @@ enum SettingsKey {
 
     // ElevenLabs options
     static let elLanguageCode = "elLanguageCode"
+
+    // Audio ducking
+    static let dimAudio = "dimAudio"
 }
 
 // MARK: - Reusable Components
@@ -108,6 +111,9 @@ struct SettingsView: View {
     // ElevenLabs options
     @State private var elLanguageCode: String
 
+    // Audio ducking
+    @State private var dimAudio: Bool
+
     var onSave: (() -> Void)?
     var onCancel: (() -> Void)?
 
@@ -136,6 +142,8 @@ struct SettingsView: View {
         _geminiTemperature = State(initialValue: d.object(forKey: SettingsKey.geminiTemperature) as? Double ?? 0.0)
 
         _elLanguageCode = State(initialValue: d.string(forKey: SettingsKey.elLanguageCode) ?? "")
+
+        _dimAudio = State(initialValue: d.object(forKey: SettingsKey.dimAudio) as? Bool ?? false)
     }
 
     private var selectedTxProvider: TranscriptionProvider {
@@ -299,6 +307,12 @@ struct SettingsView: View {
                             Text("Option").tag("option")
                         }
                         .pickerStyle(.menu)
+
+                        DescribedToggle(
+                            title: "Dim audio while recording",
+                            description: "Lowers system volume during recording for cleaner speech capture",
+                            isOn: $dimAudio
+                        )
                     }
 
                     // Transcription
@@ -432,6 +446,9 @@ struct SettingsView: View {
 
                     // ElevenLabs options
                     d.set(elLanguageCode, forKey: SettingsKey.elLanguageCode)
+
+                    // Audio ducking
+                    d.set(dimAudio, forKey: SettingsKey.dimAudio)
 
                     onSave?()
                 }

--- a/Sources/SystemAudioDucker.swift
+++ b/Sources/SystemAudioDucker.swift
@@ -1,0 +1,83 @@
+import CoreAudio
+import Foundation
+
+/// Lowers the system output volume while recording to reduce background noise picked up by the microphone,
+/// then restores it when recording stops. Uses CoreAudio to manipulate the default output device volume.
+class SystemAudioDucker {
+    private var savedVolume: Float?
+    private var isDucked = false
+    private let duckLevel: Float = 0.05
+
+    /// Lower the system output volume for cleaner speech capture.
+    func duck() {
+        guard !isDucked else { return }
+
+        guard let deviceID = defaultOutputDeviceID() else {
+            log("AudioDucker: no output device found")
+            return
+        }
+
+        if let current = getVolume(device: deviceID) {
+            savedVolume = current
+            setVolume(device: deviceID, volume: duckLevel)
+            isDucked = true
+            log("AudioDucker: ducked \(String(format: "%.0f%%", current * 100)) -> \(String(format: "%.0f%%", duckLevel * 100))")
+        }
+    }
+
+    /// Restore the system output volume to its previous level.
+    func restore() {
+        guard isDucked else { return }
+
+        guard let deviceID = defaultOutputDeviceID(),
+              let volume = savedVolume else {
+            isDucked = false
+            savedVolume = nil
+            return
+        }
+
+        setVolume(device: deviceID, volume: volume)
+        log("AudioDucker: restored to \(String(format: "%.0f%%", volume * 100))")
+        isDucked = false
+        savedVolume = nil
+    }
+
+    // MARK: - CoreAudio helpers
+
+    private func defaultOutputDeviceID() -> AudioDeviceID? {
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        )
+        return status == noErr ? deviceID : nil
+    }
+
+    private func getVolume(device: AudioDeviceID) -> Float? {
+        var volume: Float = 0
+        var size = UInt32(MemoryLayout<Float>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &volume)
+        return status == noErr ? volume : nil
+    }
+
+    private func setVolume(device: AudioDeviceID, volume: Float) {
+        var vol = volume
+        var size = UInt32(MemoryLayout<Float>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectSetPropertyData(device, &address, 0, nil, size, &vol)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SystemAudioDucker` that uses CoreAudio to lower system output volume to ~5% during recording
- Volume is always restored on recording stop, errors, silence detection, and hands-free mode exits
- Add "Dim audio while recording" toggle in Settings (off by default)

## Test plan
- [ ] Enable the toggle in Settings, start a recording, verify system audio dims
- [ ] Stop recording, verify volume restores to previous level
- [ ] Test error/silence paths still restore volume
- [ ] Test hands-free mode duck/restore cycle
- [ ] Verify toggle off = no ducking behavior

Closes #4

Generated with [Claude Code](https://claude.com/claude-code)