### PR TITLE
feat: click pill to record + onboarding state machine hardening

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -36,7 +36,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     private var isEnabled = true
     private var enableMenuItem: NSMenuItem!
     private var peakAudioLevel: Float = 0
-    private var handsFreeEntryTime: Date?
+    private var ignorePendingKeyUp = false
+
     private var shortTapCleanupWork: DispatchWorkItem?
     private var chimeWorkItem: DispatchWorkItem?
     private var onboardingHoldWork: DispatchWorkItem?
@@ -57,6 +58,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         player.play()
     }
     private var tipDismissWork: DispatchWorkItem?
+    /// The onboarding step that was active before a transient tip (.speakTip/.holdTip) appeared.
+    /// Used to enforce the same input restrictions during the tip as before it.
+    private var preTipOnboardingStep: OnboardingStep? = nil
     
     // Separate transcription and formatting engines
     private var audioTranscriber: AudioTranscriber?
@@ -266,7 +270,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         case .success:
             overlayPanel.advanceOnboarding(to: .clickTip)
         case .clickTip:
-            overlayPanel.advanceOnboarding(to: .apiTip)
+            overlayPanel.advanceOnboarding(to: .apiTip) // fallback; normally click does this
+        case .clickSuccess:
+            overlayPanel.advanceOnboarding(to: .doubleTapTip)
+        case .doubleTapTip:
+            overlayPanel.advanceOnboarding(to: .apiTip) // fallback; normally recording does this
         case .apiTip:
             overlayPanel.advanceOnboarding(to: .formattingTip)
         case .formattingTip:
@@ -289,10 +297,32 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     private func startRecording() {
         log("Key down — starting recording")
 
-        // Hold-to-confirm only for actual onboarding confirmation screens
+        // Onboarding state machine: each step defines which fn-key actions are permitted
         if let step = overlayPanel.currentOnboardingStep {
             switch step {
-            case .success, .clickTip, .apiTip, .formattingTip, .welcome:
+
+            // Click-only and double-tap-only steps: fn key fully blocked
+            case .clickTip, .doubleTapTip:
+                return
+
+            // Transient tip steps: enforce the same fn-key rules as the step that caused the tip
+            case .speakTip, .holdTip:
+                let onboardingComplete = UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete)
+                if !onboardingComplete {
+                    // Block fn key if the pre-tip step didn't allow it
+                    switch preTipOnboardingStep {
+                    case .clickTip, .doubleTapTip: return
+                    default: break
+                    }
+                    overlayPanel.advanceOnboarding(to: preTipOnboardingStep ?? .tryIt)
+                } else {
+                    overlayPanel.completeOnboarding()
+                }
+                preTipOnboardingStep = nil
+                // tipDismissWork cancelled below; fall through to recording
+
+            // Confirmation steps: fn hold advances onboarding, never starts recording
+            case .success, .clickSuccess, .apiTip, .formattingTip, .welcome:
                 log("Hold-to-confirm for: \(step)")
                 overlayPanel.pressDown()
                 let workItem = DispatchWorkItem { [weak self] in
@@ -307,28 +337,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
                 onboardingHoldWork = workItem
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: workItem)
                 return
+
+            // .tryIt: fn hold starts normal recording
             default:
-                break // .tryIt, .speakTip, .holdTip — fall through to start recording
+                break
             }
         }
 
         // Cancel any pending tip/error dismiss timers
         tipDismissWork?.cancel()
         tipDismissWork = nil
-
-        // Clear transient tip steps so the UI resets cleanly
-        if let step = overlayPanel.currentOnboardingStep {
-            switch step {
-            case .speakTip, .holdTip:
-                if UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) {
-                    overlayPanel.completeOnboarding()
-                } else {
-                    overlayPanel.advanceOnboarding(to: .tryIt)
-                }
-            default:
-                break
-            }
-        }
 
         guard isEnabled, state == .idle else {
             log("Skipped: enabled=\(isEnabled) state=\(state)")
@@ -379,10 +397,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             return
         }
 
-        // In hands-free mode, fn release stops recording (ignore the entry release)
+        // In hands-free mode, ignore the key-up only if fn was already held when we entered
         if state == .handsFreeRecording || state == .handsFreePaused {
-            if let entry = handsFreeEntryTime, Date().timeIntervalSince(entry) < 0.5 {
-                handsFreeEntryTime = nil
+            if ignorePendingKeyUp {
+                ignorePendingKeyUp = false
                 return
             }
             stopHandsFreeRecording()
@@ -566,17 +584,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     }
     
     private func showTip(_ step: OnboardingStep) {
+        // Capture which onboarding step we're on *before* the tip overwrites it.
+        // Saved as an instance property so input handlers can enforce the same restrictions.
+        let preTipStep = overlayPanel.currentOnboardingStep
+        preTipOnboardingStep = preTipStep
         state = .idle
         updateIcon(.idle)
         overlayPanel.showNoSpeech()
         overlayPanel.advanceOnboarding(to: step)
         tipDismissWork?.cancel()
         let work = DispatchWorkItem { [weak self] in
-            guard self?.overlayPanel.currentOnboardingStep == step else { return }
-            self?.overlayPanel.dismiss()
-            self?.restoreOnboardingIfNeeded()
+            guard let self, self.overlayPanel.currentOnboardingStep == step else { return }
+            self.preTipOnboardingStep = nil
+            self.overlayPanel.dismiss()
             if UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) {
-                self?.overlayPanel.completeOnboarding()
+                self.overlayPanel.completeOnboarding()
+            } else {
+                let restoreTo: OnboardingStep
+                switch preTipStep {
+                case .clickTip:    restoreTo = .clickTip
+                case .doubleTapTip: restoreTo = .doubleTapTip
+                default:           restoreTo = .tryIt
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.overlayPanel.advanceOnboarding(to: restoreTo)
+                }
             }
         }
         tipDismissWork = work
@@ -587,6 +619,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         pasteManager.paste(text)
         if overlayPanel.currentOnboardingStep == .tryIt {
             overlayPanel.advanceOnboarding(to: .success(text))
+            playSound("Submarine")
+        } else if overlayPanel.currentOnboardingStep == .clickTip {
+            overlayPanel.advanceOnboarding(to: .clickSuccess(text))
+            playSound("Submarine")
+        } else if overlayPanel.currentOnboardingStep == .doubleTapTip {
+            overlayPanel.advanceOnboarding(to: .apiTip)
             playSound("Submarine")
         }
     }
@@ -601,12 +639,51 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     // MARK: - Click-to-Record
 
     private func startClickRecording() {
-        log("Pill clicked — starting hands-free recording")
-        guard isEnabled, state == .idle else {
-            log("Skipped click: enabled=\(isEnabled) state=\(state)")
+        guard isEnabled else { return }
+        let step = overlayPanel.currentOnboardingStep
+        let onboardingComplete = UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete)
+        let onClickTip = step == .clickTip
+        // Allow click during a transient tip only if the step that caused it also allowed clicking
+        let onTransientTip = (step == .speakTip || step == .holdTip)
+            && (onboardingComplete || preTipOnboardingStep == .clickTip)
+        guard onboardingComplete || onClickTip || onTransientTip else { return }
+
+        // If already in hold-to-record, convert to hands-free so the key can be released
+        if state == .recording {
+            log("Pill clicked during hold-recording — converting to hands-free")
+            startHandsFreeRecording()
             return
         }
-        guard UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) else { return }
+
+        // If in hands-free recording/paused, stop the current session and fall through to restart
+        if state == .handsFreeRecording || state == .handsFreePaused {
+            log("Pill clicked during hands-free — stopping and restarting")
+            audioRecorder.cancel()
+            chimeWorkItem = nil
+            overlayPanel.contractHandsFree()
+            state = .idle
+            updateIcon(.idle)
+        }
+
+        guard state == .idle else {
+            log("Skipped pill click: state=\(state)")
+            return
+        }
+        log("Pill clicked — starting hands-free recording")
+
+        // Cancel any pending tip/error dismiss timers before taking over the UI
+        tipDismissWork?.cancel()
+        tipDismissWork = nil
+
+        // If interrupted a transient tip, dismiss it and restore to the pre-tip step
+        if let s = overlayPanel.currentOnboardingStep, s == .speakTip || s == .holdTip {
+            if !UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) {
+                overlayPanel.advanceOnboarding(to: preTipOnboardingStep ?? .tryIt)
+            } else {
+                overlayPanel.completeOnboarding()
+            }
+            preTipOnboardingStep = nil
+        }
 
         state = .recording
         recordingStart = Date()
@@ -628,9 +705,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
             try audioRecorder.start()
             playSound("Blow")
 
-            // Immediately enter hands-free mode
+            // Immediately enter hands-free mode (fn not held — no key-up to ignore)
             state = .handsFreeRecording
-            handsFreeEntryTime = nil
+            ignorePendingKeyUp = false
             overlayPanel.showHandsFreeRecording(
                 onPauseResume: { [weak self] in self?.toggleHandsFreePause() },
                 onStop: { [weak self] in self?.stopHandsFreeRecording() }
@@ -648,23 +725,50 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
     private func startHandsFreeRecording() {
         log("Double-tap — entering hands-free mode")
 
-        // Cancel pending short-tap cleanup from the first tap
         shortTapCleanupWork?.cancel()
         shortTapCleanupWork = nil
 
-        // Must already be recording (from the first tap's onKeyDown)
-        guard state == .recording else { return }
+        let onDoubleTapTip = overlayPanel.currentOnboardingStep == .doubleTapTip
+        guard UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) || onDoubleTapTip else { return }
 
-        // Don't allow hands-free during onboarding
-        guard UserDefaults.standard.bool(forKey: SettingsKey.onboardingComplete) else { return }
-
-        state = .handsFreeRecording
-        handsFreeEntryTime = Date()
-
-        overlayPanel.showHandsFreeRecording(
-            onPauseResume: { [weak self] in self?.toggleHandsFreePause() },
-            onStop: { [weak self] in self?.stopHandsFreeRecording() }
-        )
+        if state == .recording {
+            // Normal path: first tap started recording, convert it to hands-free
+            state = .handsFreeRecording
+            ignorePendingKeyUp = hotkeyManager.isHeld
+            overlayPanel.showHandsFreeRecording(
+                onPauseResume: { [weak self] in self?.toggleHandsFreePause() },
+                onStop: { [weak self] in self?.stopHandsFreeRecording() }
+            )
+        } else if state == .idle && onDoubleTapTip {
+            // doubleTapTip path: fn key was blocked on first tap, so start recorder now
+            guard isEnabled else { return }
+            recordingStart = Date()
+            peakAudioLevel = 0
+            updateIcon(.recording)
+            overlayPanel.showRecording()
+            audioRecorder.onLevelUpdate = { [weak self] level in
+                self?.overlayPanel.updateLevel(level)
+                if level > (self?.peakAudioLevel ?? 0) { self?.peakAudioLevel = level }
+            }
+            audioRecorder.onBandLevels = { [weak self] bands in
+                self?.overlayPanel.updateBandLevels(bands)
+            }
+            do {
+                try audioRecorder.start()
+                state = .handsFreeRecording
+                ignorePendingKeyUp = hotkeyManager.isHeld
+                overlayPanel.showHandsFreeRecording(
+                    onPauseResume: { [weak self] in self?.toggleHandsFreePause() },
+                    onStop: { [weak self] in self?.stopHandsFreeRecording() }
+                )
+                playSound("Blow")
+            } catch {
+                log("Recording failed: \(error)")
+                state = .idle
+                updateIcon(.idle)
+                overlayPanel.dismiss()
+            }
+        }
     }
 
     private func toggleHandsFreePause() {
@@ -723,6 +827,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SettingsDelegate {
         if step == .tryIt || step == .speakTip || step == .holdTip {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
                 self?.overlayPanel.advanceOnboarding(to: .tryIt)
+            }
+        } else if step == .clickTip {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.overlayPanel.advanceOnboarding(to: .clickTip)
+            }
+        } else if step == .doubleTapTip {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.overlayPanel.advanceOnboarding(to: .doubleTapTip)
             }
         }
     }

--- a/Sources/OverlayPanel.swift
+++ b/Sources/OverlayPanel.swift
@@ -8,13 +8,20 @@ class ClickTargetView: NSView {
     override func mouseDown(with event: NSEvent) { onClick?() }
 }
 
-/// Content view that passes clicks through except on ClickTargetViews.
+/// Content view that passes clicks through except on ClickTargetViews and the pill region.
 class OverlayContentView: NSView {
+    var pillHitRegion: NSRect = .zero
+
     override func hitTest(_ point: NSPoint) -> NSView? {
+        // Pause/stop ClickTargetViews always take priority
         for subview in subviews.reversed() {
             guard subview is ClickTargetView else { continue }
             let local = convert(point, to: subview)
             if subview.bounds.contains(local) { return subview }
+        }
+        // Forward pill-area clicks to the hosting view so SwiftUI gestures fire naturally
+        if pillHitRegion.contains(point) {
+            return super.hitTest(point)
         }
         return nil
     }
@@ -27,6 +34,7 @@ class OverlayPanel: NSPanel {
     private var errorDismissWork: DispatchWorkItem?
     private var pauseTarget: ClickTargetView?
     private var stopTarget: ClickTargetView?
+    private var contentOverlay: OverlayContentView?
 
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
@@ -55,6 +63,7 @@ class OverlayPanel: NSPanel {
         hidesOnDeactivate = false
 
         let container = OverlayContentView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        contentOverlay = container
 
         let hostingView = NSHostingView(rootView:
             OverlayView(state: overlayState)
@@ -75,6 +84,7 @@ class OverlayPanel: NSPanel {
         stopTarget = stop
 
         contentView = container
+        updatePillTarget()
     }
     
     func showRecording() {
@@ -86,13 +96,13 @@ class OverlayPanel: NSPanel {
         withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: 0.5)) {
             overlayState.mode = .recording
         }
+        updatePillTarget()
     }
 
     func showHandsFreeRecording(onPauseResume: @escaping () -> Void, onStop: @escaping () -> Void) {
         overlayState.onPauseResume = onPauseResume
         overlayState.onStop = onStop
         overlayState.isPaused = false
-        overlayState.onboardingStep = nil
         overlayState.isHandsFree = true
         updateButtonTargets()
     }
@@ -133,6 +143,24 @@ class OverlayPanel: NSPanel {
                              width: targetRadius * 2, height: targetRadius * 2)
     }
 
+    /// Update the pill hit region so SwiftUI tap gestures reach the correct pill position.
+    private func updatePillTarget() {
+        let cx = frame.width / 2  // 700
+        let isExpanded = overlayState.mode != .idle || overlayState.onboardingStep != nil
+        switch overlayState.mode {
+        case .processing:
+            contentOverlay?.pillHitRegion = .zero
+        default:
+            if isExpanded {
+                // Expanded pill center = panel y 415
+                contentOverlay?.pillHitRegion = NSRect(x: cx - 40, y: 395, width: 80, height: 40)
+            } else {
+                // Minimized pill center ≈ panel y 385
+                contentOverlay?.pillHitRegion = NSRect(x: cx - 40, y: 371, width: 80, height: 28)
+            }
+        }
+    }
+
     func updateBandLevels(_ levels: [Float]) {
         overlayState.bandLevels = levels
     }
@@ -151,10 +179,12 @@ class OverlayPanel: NSPanel {
         overlayState.onPauseResume = nil
         overlayState.onStop = nil
         overlayState.mode = .processing
+        updatePillTarget()
     }
 
     func showError(_ message: String) {
         overlayState.mode = .error(message)
+        updatePillTarget()
         errorDismissWork?.cancel()
         let work = DispatchWorkItem { [weak self] in
             self?.dismiss()
@@ -171,6 +201,7 @@ class OverlayPanel: NSPanel {
         withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: 0.35)) {
             overlayState.mode = .idle
         }
+        updatePillTarget()
     }
 
     var currentOnboardingStep: OnboardingStep? {
@@ -181,6 +212,7 @@ class OverlayPanel: NSPanel {
         withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: 0.5)) {
             overlayState.onboardingStep = step
         }
+        updatePillTarget()
     }
 
     func setHotkeyLabel(_ label: String) {
@@ -214,6 +246,7 @@ class OverlayPanel: NSPanel {
         withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: 0.35)) {
             overlayState.onboardingStep = nil
         }
+        updatePillTarget()
     }
 
     func setOnClickToRecord(_ callback: @escaping () -> Void) {
@@ -246,6 +279,8 @@ enum OnboardingStep: Hashable {
     case tryIt
     case success(String)
     case clickTip
+    case clickSuccess(String)
+    case doubleTapTip
     case apiTip
     case formattingTip
     case welcome
@@ -276,7 +311,7 @@ struct OverlayView: View {
     @ObservedObject var state: OverlayState
     @State private var shakeProgress: CGFloat = 0
 
-    private var isActive: Bool { state.mode != .idle || state.isOnboarding || state.isHovering }
+    private var isActive: Bool { state.mode != .idle || state.isOnboarding }
     private var isExpanded: Bool { state.mode != .idle || state.isOnboarding }
     private var isMinimized: Bool { state.mode == .idle && !state.isOnboarding }
 
@@ -305,7 +340,7 @@ struct OverlayView: View {
             if showGradient {
                 LavaLampBackground(energy: gradientEnergy)
                     .allowsHitTesting(false)
-                    .transition(.opacity)
+                    .transition(.opacity.combined(with: .offset(y: 60)))
                     .animation(.easeInOut(duration: 0.8), value: gradientEnergy)
             }
 
@@ -339,12 +374,12 @@ struct OverlayView: View {
                 .contentShape(Capsule())
                 .onHover { hovering in
                     guard isMinimized else { return }
-                    withAnimation(.easeInOut(duration: 0.3)) {
+                    withAnimation(.easeOut(duration: 0.35)) {
                         state.isHovering = hovering
                     }
                 }
                 .onTapGesture {
-                    guard isMinimized else { return }
+                    guard state.mode != .processing else { return }
                     state.onClickToRecord?()
                 }
                 .scaleEffect(pillScale * audioBounceFactor * (state.isPressed ? 0.85 : 1.0) * (state.mode == .processing ? 0.8 : 1.0))
@@ -369,12 +404,12 @@ struct OverlayView: View {
                 }
                 .overlay(alignment: .bottom) {
                     if state.isHovering && isMinimized {
-                        Text("ready when you are")
-                            .font(.system(size: 12, weight: .medium).italic())
-                            .foregroundColor(.white.opacity(0.8))
-                            .shadow(color: .black.opacity(0.4), radius: 4, y: 1)
+                        Text("Click to start transcribing")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.white)
+                            .shadow(color: .black.opacity(0.6), radius: 6, y: 2)
                             .fixedSize()
-                            .offset(y: -32)
+                            .offset(y: -6)
                             .transition(.opacity.combined(with: .offset(y: 4)))
                     }
                 }
@@ -403,7 +438,7 @@ struct OverlayView: View {
     private var showHoldPromptInPill: Bool {
         guard let step = state.onboardingStep, state.mode == .idle || state.mode == .noSpeech else { return false }
         switch step {
-        case .success, .clickTip, .apiTip, .formattingTip, .welcome:
+        case .success, .clickSuccess, .apiTip, .formattingTip, .welcome:
             return true
         default:
             return false
@@ -593,8 +628,22 @@ struct OnboardingCardView: View {
                         .multilineTextAlignment(.center)
                 }
             case .clickTip:
-                Text("You can also click the pill to start recording")
+                Text("Now try clicking the pill to record")
                     .multilineTextAlignment(.center)
+            case .clickSuccess(let text):
+                VStack(spacing: 6) {
+                    Text("You said:")
+                        .foregroundColor(.white.opacity(0.6))
+                    Text("\"\(text)\"")
+                        .italic()
+                        .multilineTextAlignment(.center)
+                }
+            case .doubleTapTip:
+                HStack(spacing: 6) {
+                    Text("Now try double-tapping")
+                    KeyCapView(label: hotkeyLabel)
+                    Text("to record")
+                }
             case .apiTip:
                 Text("Add an API key in the menu bar for better transcription")
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
## Summary

- **Click pill to start recording** — clicking the minimized or expanded pill now starts hands-free recording at any time (except during processing or locked onboarding steps)
- **Onboarding state machine** — each step now strictly controls which inputs are allowed (fn-only, click-only, double-tap-only, hold-to-confirm)
- **Error/tip recovery** — transient tips (`.speakTip`, `.holdTip`) are immediately interruptible; user is never stuck waiting for auto-dismiss
- **Tip inherits parent step restrictions** — if `.speakTip` appears during `.clickTip`, only pill click can dismiss it (fn key stays blocked)

## Issues closed

Closes #29, #30, #31, #32

## Key changes

- \`OverlayPanel.showHandsFreeRecording()\`: stop clearing \`onboardingStep\` (was breaking clickTip → clickSuccess advancement)
- \`startRecording()\`: unified switch covering all onboarding steps with explicit cases for click-only, double-tap-only, hold-to-confirm, and transient tip states
- \`startHandsFreeRecording()\`: new idle→hands-free path for \`doubleTapTip\` since fn key is now blocked on first press
- \`startClickRecording()\`: cancel \`tipDismissWork\` before recording; allow click during transient tips when parent step permits it
- \`showTip()\`: save \`preTipOnboardingStep\` so restrictions carry through the tip

## Test plan

- [ ] Click minimized pill → starts recording
- [ ] Click pill during error/noSpeech → immediately starts new recording
- [ ] Onboarding \`.tryIt\`: fn hold works, clicking blocked
- [ ] Onboarding \`.clickTip\`: only pill click works, fn blocked; after speaking, advances to \`.clickSuccess\`
- [ ] Onboarding \`.doubleTapTip\`: only double-tap works; single hold does nothing
- [ ] Onboarding \`.clickTip\` + silence → \`.speakTip\` shows → fn still blocked, click still works
- [ ] Post-onboarding error → fn or click immediately resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)