### PR TITLE
fix: harden native hotkey handling

### DIFF
--- a/tauri-app/src-tauri/build.rs
+++ b/tauri-app/src-tauri/build.rs
@@ -8,8 +8,8 @@ fn main() {
         let profile = std::env::var("PROFILE").unwrap_or_default();
         if profile == "release" {
             let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-            let script = std::path::PathBuf::from(&manifest_dir)
-                .join("sidecar-overlay/build-sidecar.sh");
+            let script =
+                std::path::PathBuf::from(&manifest_dir).join("sidecar-overlay/build-sidecar.sh");
 
             if script.exists() {
                 let status = std::process::Command::new("bash")

--- a/tauri-app/src-tauri/src/audio.rs
+++ b/tauri-app/src-tauri/src/audio.rs
@@ -68,7 +68,9 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
 
     let host = cpal::default_host();
     let device = resolve_input_device(&host, device_name)?;
-    let resolved_device_name = device.name().unwrap_or_else(|_| "unknown input device".to_string());
+    let resolved_device_name = device
+        .name()
+        .unwrap_or_else(|_| "unknown input device".to_string());
 
     let config = device
         .default_input_config()
@@ -142,7 +144,15 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
                 cpal::SampleFormat::F32 => device.build_input_stream(
                     &stream_config,
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                        process_audio_callback(data, channels, sr, &writer_cb, &levels_cb, &peak_cb, &fft_buf_cb);
+                        process_audio_callback(
+                            data,
+                            channels,
+                            sr,
+                            &writer_cb,
+                            &levels_cb,
+                            &peak_cb,
+                            &fft_buf_cb,
+                        );
                     },
                     err_fn,
                     None,
@@ -151,8 +161,17 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
                     &stream_config,
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
                         // Convert i16 to f32
-                        let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
-                        process_audio_callback(&f32_data, channels, sr, &writer_cb, &levels_cb, &peak_cb, &fft_buf_cb);
+                        let f32_data: Vec<f32> =
+                            data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
+                        process_audio_callback(
+                            &f32_data,
+                            channels,
+                            sr,
+                            &writer_cb,
+                            &levels_cb,
+                            &peak_cb,
+                            &fft_buf_cb,
+                        );
                     },
                     err_fn,
                     None,
@@ -165,7 +184,15 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
                             .iter()
                             .map(|&s| (s as f32 / u16::MAX as f32) * 2.0 - 1.0)
                             .collect();
-                        process_audio_callback(&f32_data, channels, sr, &writer_cb, &levels_cb, &peak_cb, &fft_buf_cb);
+                        process_audio_callback(
+                            &f32_data,
+                            channels,
+                            sr,
+                            &writer_cb,
+                            &levels_cb,
+                            &peak_cb,
+                            &fft_buf_cb,
+                        );
                     },
                     err_fn,
                     None,
@@ -330,7 +357,8 @@ fn process_audio_callback(
         if let Ok(mut guard) = writer.lock() {
             if let Some(ref mut w) = *guard {
                 for &sample in &mono_samples {
-                    let s16 = (sample * i16::MAX as f32).clamp(i16::MIN as f32, i16::MAX as f32) as i16;
+                    let s16 =
+                        (sample * i16::MAX as f32).clamp(i16::MIN as f32, i16::MAX as f32) as i16;
                     let _ = w.write_sample(s16);
                 }
             }
@@ -432,10 +460,7 @@ pub fn resume_recording() {
 
 /// Get the current real-time audio levels (for overlay rendering).
 pub fn get_levels() -> AudioLevels {
-    CURRENT_LEVELS
-        .lock()
-        .map(|l| l.clone())
-        .unwrap_or_default()
+    CURRENT_LEVELS.lock().map(|l| l.clone()).unwrap_or_default()
 }
 
 /// List available audio input devices by name.
@@ -495,10 +520,10 @@ fn compute_bands(samples: &[f32], sample_rate: f32) -> [f32; RAW_BAND_COUNT] {
 
     let mut bands = [0.0f32; RAW_BAND_COUNT];
     for i in 0..RAW_BAND_COUNT {
-        let freq_low = 2.0f32
-            .powf(log_min + (log_max - log_min) * i as f32 / RAW_BAND_COUNT as f32);
-        let freq_high = 2.0f32
-            .powf(log_min + (log_max - log_min) * (i + 1) as f32 / RAW_BAND_COUNT as f32);
+        let freq_low =
+            2.0f32.powf(log_min + (log_max - log_min) * i as f32 / RAW_BAND_COUNT as f32);
+        let freq_high =
+            2.0f32.powf(log_min + (log_max - log_min) * (i + 1) as f32 / RAW_BAND_COUNT as f32);
         let bin_low = (freq_low / bin_width).max(1.0) as usize;
         let bin_high = (freq_high / bin_width).min((half - 1) as f32) as usize;
 
@@ -535,16 +560,16 @@ fn compute_bands(samples: &[f32], sample_rate: f32) -> [f32; RAW_BAND_COUNT] {
 /// Outer bars blend in more of the neighboring bands so they're not starved.
 fn mirror_bands(raw: &[f32; RAW_BAND_COUNT]) -> [f32; 11] {
     [
-        raw[5] * 0.5 + raw[4] * 0.3 + raw[3] * 0.2,  // bar 0  (leftmost)
-        raw[4] * 0.5 + raw[3] * 0.3 + raw[5] * 0.2,  // bar 1
+        raw[5] * 0.5 + raw[4] * 0.3 + raw[3] * 0.2, // bar 0  (leftmost)
+        raw[4] * 0.5 + raw[3] * 0.3 + raw[5] * 0.2, // bar 1
         raw[3] * 0.6 + raw[2] * 0.25 + raw[4] * 0.15, // bar 2
-        raw[2] * 0.7 + raw[1] * 0.2 + raw[3] * 0.1,   // bar 3
+        raw[2] * 0.7 + raw[1] * 0.2 + raw[3] * 0.1, // bar 3
         raw[1] * 0.8 + raw[0] * 0.15 + raw[2] * 0.05, // bar 4
-        raw[0],                                          // bar 5  (center)
+        raw[0],                                     // bar 5  (center)
         raw[1] * 0.85 + raw[0] * 0.1 + raw[2] * 0.05, // bar 6
-        raw[2] * 0.7 + raw[1] * 0.2 + raw[3] * 0.1,   // bar 7
+        raw[2] * 0.7 + raw[1] * 0.2 + raw[3] * 0.1, // bar 7
         raw[3] * 0.6 + raw[2] * 0.25 + raw[4] * 0.15, // bar 8
-        raw[4] * 0.5 + raw[3] * 0.3 + raw[5] * 0.2,   // bar 9
-        raw[5] * 0.5 + raw[4] * 0.3 + raw[3] * 0.2,   // bar 10 (rightmost)
+        raw[4] * 0.5 + raw[3] * 0.3 + raw[5] * 0.2, // bar 9
+        raw[5] * 0.5 + raw[4] * 0.3 + raw[3] * 0.2, // bar 10 (rightmost)
     ]
 }

--- a/tauri-app/src-tauri/src/config.rs
+++ b/tauri-app/src-tauri/src/config.rs
@@ -191,8 +191,7 @@ pub fn load() -> Result<AppConfig, String> {
     let path = config_path()?;
 
     let config = if path.exists() {
-        let data = fs::read_to_string(&path)
-            .map_err(|e| format!("failed to read config: {e}"))?;
+        let data = fs::read_to_string(&path).map_err(|e| format!("failed to read config: {e}"))?;
         serde_json::from_str::<AppConfig>(&data).unwrap_or_else(|_| {
             // File exists but is malformed -- fall back to defaults.
             AppConfig::default()
@@ -225,10 +224,7 @@ pub fn save(config: &AppConfig) -> Result<(), String> {
 
 /// Get a snapshot of the current in-memory config.
 pub fn get() -> AppConfig {
-    CONFIG
-        .lock()
-        .map(|g| g.clone())
-        .unwrap_or_default()
+    CONFIG.lock().map(|g| g.clone()).unwrap_or_default()
 }
 
 /// Update a single field via a closure, persist, and return the new config.

--- a/tauri-app/src-tauri/src/hotkey.rs
+++ b/tauri-app/src-tauri/src/hotkey.rs
@@ -8,6 +8,7 @@ static RUNNING: AtomicBool = AtomicBool::new(false);
 
 /// Callback type for hotkey events.
 type HotkeyCallback = Box<dyn Fn() + Send + 'static>;
+type CaptureCallback = Box<dyn Fn(String) + Send + 'static>;
 
 /// Stored callbacks for hotkey events (set by the caller before start).
 static CALLBACKS: once_cell::sync::Lazy<Mutex<HotkeyCallbacks>> =
@@ -19,6 +20,9 @@ static CALLBACKS: once_cell::sync::Lazy<Mutex<HotkeyCallbacks>> =
         })
     });
 
+static CAPTURE_CALLBACKS: once_cell::sync::Lazy<Mutex<Option<CaptureCallbacks>>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(None));
+
 struct HotkeyCallbacks {
     on_key_down: Option<HotkeyCallback>,
     on_key_up: Option<HotkeyCallback>,
@@ -29,11 +33,213 @@ struct HotkeyCallbacks {
 // protect access via a Mutex.
 unsafe impl Send for HotkeyCallbacks {}
 
-/// Hotkey modifier the user has configured.
+struct CaptureCallbacks {
+    on_preview: CaptureCallback,
+    on_capture: CaptureCallback,
+}
+
+/// Modifier keys supported in configurable shortcuts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HotkeyModifier {
-    Fn,
+    Command,
+    Control,
     Option,
+    Shift,
+    Fn,
+}
+
+/// Hotkey shortcut the user has configured.
+///
+/// `triggers` is empty for modifier-only shortcuts such as `fn`, `option`, or
+/// `cmd+shift`. Non-modifier triggers use canonical names such as `space`,
+/// `a`, `1`, `return`, `left`, or `f12`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotkeySpec {
+    pub modifiers: Vec<HotkeyModifier>,
+    pub triggers: Vec<String>,
+}
+
+impl HotkeySpec {
+    pub fn parse(value: &str) -> Self {
+        Self::try_parse(value).unwrap_or_else(|| Self {
+            modifiers: vec![HotkeyModifier::Fn],
+            triggers: Vec::new(),
+        })
+    }
+
+    pub fn try_parse(value: &str) -> Option<Self> {
+        let normalized = value.trim().replace(' ', "").to_lowercase();
+        if normalized.is_empty() {
+            return None;
+        }
+
+        let mut modifiers = Vec::new();
+        let mut triggers: Vec<String> = Vec::new();
+
+        for raw_part in normalized.split('+').filter(|part| !part.is_empty()) {
+            if let Some(modifier) = parse_modifier(raw_part) {
+                if !modifiers.contains(&modifier) {
+                    modifiers.push(modifier);
+                }
+                continue;
+            }
+
+            let key = normalize_key(raw_part)?;
+            if !triggers.contains(&key) {
+                triggers.push(key);
+            }
+        }
+
+        if modifiers.is_empty() && triggers.is_empty() {
+            return None;
+        }
+
+        modifiers.sort_by_key(|modifier| modifier_order(*modifier));
+
+        Some(Self {
+            modifiers,
+            triggers,
+        })
+    }
+
+    pub fn label(&self) -> String {
+        self.parts()
+            .into_iter()
+            .map(|part| label_part(&part))
+            .collect::<Vec<_>>()
+            .join("+")
+    }
+
+    pub fn canonical(&self) -> String {
+        self.parts().join("+")
+    }
+
+    fn parts(&self) -> Vec<String> {
+        let mut parts = self
+            .modifiers
+            .iter()
+            .map(|modifier| match modifier {
+                HotkeyModifier::Command => "cmd".to_string(),
+                HotkeyModifier::Control => "ctrl".to_string(),
+                HotkeyModifier::Option => "option".to_string(),
+                HotkeyModifier::Shift => "shift".to_string(),
+                HotkeyModifier::Fn => "fn".to_string(),
+            })
+            .collect::<Vec<_>>();
+
+        for trigger in &self.triggers {
+            parts.push(trigger.clone());
+        }
+
+        parts
+    }
+}
+
+fn parse_modifier(value: &str) -> Option<HotkeyModifier> {
+    match value {
+        "cmd" | "command" | "meta" | "super" => Some(HotkeyModifier::Command),
+        "ctrl" | "control" => Some(HotkeyModifier::Control),
+        "alt" | "option" => Some(HotkeyModifier::Option),
+        "shift" => Some(HotkeyModifier::Shift),
+        "fn" | "globe" => Some(HotkeyModifier::Fn),
+        _ => None,
+    }
+}
+
+fn normalize_key(value: &str) -> Option<String> {
+    let key = match value {
+        "esc" => "escape",
+        "enter" => "return",
+        "backspace" => "delete",
+        "del" => "forwarddelete",
+        "uparrow" | "arrowup" => "up",
+        "downarrow" | "arrowdown" => "down",
+        "leftarrow" | "arrowleft" => "left",
+        "rightarrow" | "arrowright" => "right",
+        "plus" => "=",
+        "minus" => "-",
+        "comma" => ",",
+        "period" => ".",
+        "slash" => "/",
+        "backslash" => "\\",
+        "semicolon" => ";",
+        "quote" => "'",
+        "backquote" | "grave" => "`",
+        "leftbracket" => "[",
+        "rightbracket" => "]",
+        "space" | "tab" | "return" | "escape" | "delete" | "forwarddelete" | "capslock"
+        | "home" | "end" | "pageup" | "pagedown" | "left" | "right" | "up" | "down" => value,
+        _ if value
+            .strip_prefix("keycode:")
+            .and_then(|raw| raw.parse::<i64>().ok())
+            .is_some() =>
+        {
+            value
+        }
+        _ if value
+            .strip_prefix("vk:")
+            .and_then(|raw| raw.parse::<u16>().ok())
+            .is_some() =>
+        {
+            value
+        }
+        _ if value.len() == 1 => value,
+        _ if value.starts_with('f')
+            && value[1..]
+                .parse::<u8>()
+                .ok()
+                .is_some_and(|n| (1..=20).contains(&n)) =>
+        {
+            value
+        }
+        _ => return None,
+    };
+
+    Some(key.to_string())
+}
+
+fn modifier_order(modifier: HotkeyModifier) -> u8 {
+    match modifier {
+        HotkeyModifier::Command => 0,
+        HotkeyModifier::Control => 1,
+        HotkeyModifier::Option => 2,
+        HotkeyModifier::Shift => 3,
+        HotkeyModifier::Fn => 4,
+    }
+}
+
+fn label_part(value: &str) -> String {
+    match value {
+        "cmd" => "Cmd".to_string(),
+        "ctrl" => "Ctrl".to_string(),
+        "option" => "Option".to_string(),
+        "shift" => "Shift".to_string(),
+        "fn" => "fn".to_string(),
+        "space" => "Space".to_string(),
+        "return" => "Return".to_string(),
+        "escape" => "Esc".to_string(),
+        "delete" => "Delete".to_string(),
+        "forwarddelete" => "Forward Delete".to_string(),
+        "capslock" => "Caps Lock".to_string(),
+        "pageup" => "Page Up".to_string(),
+        "pagedown" => "Page Down".to_string(),
+        "left" => "Left".to_string(),
+        "right" => "Right".to_string(),
+        "up" => "Up".to_string(),
+        "down" => "Down".to_string(),
+        "home" => "Home".to_string(),
+        "end" => "End".to_string(),
+        "tab" => "Tab".to_string(),
+        _ if value.starts_with("keycode:") => value
+            .strip_prefix("keycode:")
+            .map(|raw| format!("Key {raw}"))
+            .unwrap_or_else(|| value.to_string()),
+        _ if value.starts_with("vk:") => value
+            .strip_prefix("vk:")
+            .map(|raw| format!("Key {raw}"))
+            .unwrap_or_else(|| value.to_string()),
+        _ => value.to_string(),
+    }
 }
 
 /// Double-tap detection window in seconds.
@@ -53,6 +259,55 @@ pub fn set_callbacks(
         cb.on_key_down = Some(Box::new(on_key_down));
         cb.on_key_up = Some(Box::new(on_key_up));
         cb.on_double_tap = Some(Box::new(on_double_tap));
+    }
+}
+
+pub fn begin_capture(
+    on_preview: impl Fn(String) + Send + 'static,
+    on_capture: impl Fn(String) + Send + 'static,
+) {
+    if let Ok(mut capture) = CAPTURE_CALLBACKS.lock() {
+        *capture = Some(CaptureCallbacks {
+            on_preview: Box::new(on_preview),
+            on_capture: Box::new(on_capture),
+        });
+    }
+    platform::reset_capture_state();
+}
+
+pub fn cancel_capture() {
+    if let Ok(mut capture) = CAPTURE_CALLBACKS.lock() {
+        *capture = None;
+    }
+    platform::reset_capture_state();
+}
+
+fn is_capturing() -> bool {
+    CAPTURE_CALLBACKS
+        .lock()
+        .ok()
+        .is_some_and(|capture| capture.is_some())
+}
+
+fn preview_capture(shortcut: String) {
+    if let Ok(capture) = CAPTURE_CALLBACKS.lock() {
+        if let Some(callbacks) = capture.as_ref() {
+            (callbacks.on_preview)(shortcut);
+        }
+    }
+}
+
+fn finish_capture(shortcut: String) {
+    let callback = CAPTURE_CALLBACKS
+        .lock()
+        .ok()
+        .and_then(|mut capture| capture.take())
+        .map(|callbacks| callbacks.on_capture);
+
+    platform::reset_capture_state();
+
+    if let Some(callback) = callback {
+        callback(shortcut);
     }
 }
 
@@ -138,7 +393,11 @@ mod platform {
 
         fn CFRunLoopRemoveSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
 
-        fn CFRunLoopRunInMode(mode: CFStringRef, seconds: f64, return_after_source_handled: u8) -> i32;
+        fn CFRunLoopRunInMode(
+            mode: CFStringRef,
+            seconds: f64,
+            return_after_source_handled: u8,
+        ) -> i32;
 
         fn CFRelease(cf: *const std::ffi::c_void);
 
@@ -162,11 +421,31 @@ mod platform {
     /// Whether the current held key press already fired the double-tap callback.
     static CURRENT_PRESS_IS_DOUBLE_TAP: AtomicBool = AtomicBool::new(false);
 
-    /// The modifier mask we're monitoring (raw u64 flags).
-    static MODIFIER_MASK: AtomicU64 = AtomicU64::new(0);
+    /// Required modifier flags for the configured shortcut.
+    static REQUIRED_MODIFIER_FLAGS: AtomicU64 = AtomicU64::new(0);
 
-    /// Whether we're monitoring the fn/Globe key.
-    static IS_FN_KEY: AtomicBool = AtomicBool::new(false);
+    /// The configured non-modifier keycodes. Empty means modifier-only.
+    static TRIGGER_KEYCODES: once_cell::sync::Lazy<Mutex<Vec<i64>>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+    /// Currently held configured non-modifier keycodes.
+    static PRESSED_TRIGGER_KEYCODES: once_cell::sync::Lazy<Mutex<Vec<i64>>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+    /// Last modifier-only candidate observed while native shortcut capture is active.
+    static CAPTURE_MODIFIER_FLAGS: AtomicU64 = AtomicU64::new(0);
+
+    static CAPTURE_TRIGGER_KEYCODES: once_cell::sync::Lazy<Mutex<Vec<i64>>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+    static CAPTURE_LAST_SHORTCUT: once_cell::sync::Lazy<Mutex<String>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(String::new()));
+
+    const ALL_MODIFIER_FLAGS: u64 = K_CG_EVENT_FLAG_MASK_SHIFT
+        | K_CG_EVENT_FLAG_MASK_CONTROL
+        | K_CG_EVENT_FLAG_MASK_ALTERNATE
+        | K_CG_EVENT_FLAG_MASK_COMMAND
+        | K_CG_EVENT_FLAG_MASK_SECONDARY_FN;
 
     fn now_micros() -> u64 {
         SystemTime::now()
@@ -175,19 +454,23 @@ mod platform {
             .as_micros() as u64
     }
 
-    /// Install a CGEventTap that listens for the configured modifier key.
-    pub fn start(modifier: HotkeyModifier) {
+    /// Install a CGEventTap that listens for the configured shortcut.
+    pub fn start(spec: HotkeySpec) {
         if RUNNING.swap(true, Ordering::SeqCst) {
             return; // already running
         }
 
-        let (mask, is_fn) = match modifier {
-            HotkeyModifier::Fn => (K_CG_EVENT_FLAG_MASK_SECONDARY_FN, true),
-            HotkeyModifier::Option => (K_CG_EVENT_FLAG_MASK_ALTERNATE, false),
-        };
-
-        MODIFIER_MASK.store(mask, Ordering::SeqCst);
-        IS_FN_KEY.store(is_fn, Ordering::SeqCst);
+        REQUIRED_MODIFIER_FLAGS.store(modifier_flags(&spec), Ordering::SeqCst);
+        if let Ok(mut triggers) = TRIGGER_KEYCODES.lock() {
+            *triggers = spec
+                .triggers
+                .iter()
+                .filter_map(|trigger| keycode_for_trigger(trigger))
+                .collect();
+        }
+        if let Ok(mut pressed) = PRESSED_TRIGGER_KEYCODES.lock() {
+            pressed.clear();
+        }
         IS_HELD.store(false, Ordering::SeqCst);
         LAST_KEY_UP.store(0, Ordering::SeqCst);
         KEY_DOWN_AT.store(0, Ordering::SeqCst);
@@ -276,14 +559,65 @@ mod platform {
             return event;
         }
 
-        // Suppress fn/Globe keyDown/keyUp that trigger the emoji picker
+        if is_capturing() {
+            match capture_event(event_type, event) {
+                CaptureAction::Captured(shortcut) => {
+                    finish_capture(shortcut);
+                    return std::ptr::null_mut();
+                }
+                CaptureAction::Consume => return std::ptr::null_mut(),
+                CaptureAction::Ignore => {}
+            }
+        }
+
+        let trigger_keycodes = TRIGGER_KEYCODES
+            .lock()
+            .ok()
+            .map(|t| t.clone())
+            .unwrap_or_default();
+        let required_flags = REQUIRED_MODIFIER_FLAGS.load(Ordering::SeqCst);
+        let is_modifier_only = trigger_keycodes.is_empty();
+
+        // Suppress fn/Globe keyDown/keyUp that trigger the emoji picker.
         if event_type == K_CG_EVENT_KEY_DOWN || event_type == K_CG_EVENT_KEY_UP {
-            if IS_FN_KEY.load(Ordering::SeqCst) {
+            if (required_flags & K_CG_EVENT_FLAG_MASK_SECONDARY_FN) != 0 {
                 let keycode = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE);
                 if keycode == 63 || keycode == 179 {
                     return std::ptr::null_mut(); // consume event
                 }
             }
+
+            if is_modifier_only {
+                return event;
+            }
+
+            let keycode = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE);
+            if !trigger_keycodes.contains(&keycode) {
+                return event;
+            }
+
+            let flags = CGEventGetFlags(event);
+            let modifiers_active = modifiers_match(flags, required_flags);
+
+            if event_type == K_CG_EVENT_KEY_DOWN {
+                mark_trigger_pressed(keycode);
+                if modifiers_active
+                    && all_triggers_pressed(&trigger_keycodes)
+                    && !IS_HELD.load(Ordering::SeqCst)
+                {
+                    fire_key_down();
+                }
+                if IS_HELD.load(Ordering::SeqCst) {
+                    return std::ptr::null_mut();
+                }
+            } else if event_type == K_CG_EVENT_KEY_UP && IS_HELD.load(Ordering::SeqCst) {
+                unmark_trigger_pressed(keycode);
+                fire_key_up();
+                return std::ptr::null_mut();
+            } else if event_type == K_CG_EVENT_KEY_UP {
+                unmark_trigger_pressed(keycode);
+            }
+
             return event;
         }
 
@@ -291,75 +625,353 @@ mod platform {
             return event;
         }
 
-        let mask = MODIFIER_MASK.load(Ordering::SeqCst);
         let flags = CGEventGetFlags(event);
-        let trigger_active = (flags & mask) != 0;
+        let modifiers_active = modifiers_match(flags, required_flags);
 
-        // Only trigger if no other modifiers are held
-        let other_modifiers = K_CG_EVENT_FLAG_MASK_SHIFT
-            | K_CG_EVENT_FLAG_MASK_CONTROL
-            | K_CG_EVENT_FLAG_MASK_ALTERNATE
-            | K_CG_EVENT_FLAG_MASK_COMMAND;
-        let relevant_others = flags & other_modifiers & !mask;
-        let has_other_modifiers = relevant_others != 0;
-
-        if trigger_active && !has_other_modifiers && !IS_HELD.load(Ordering::SeqCst) {
-            IS_HELD.store(true, Ordering::SeqCst);
-
-            let last_up = LAST_KEY_UP.load(Ordering::SeqCst);
-            let now = now_micros();
-            KEY_DOWN_AT.store(now, Ordering::SeqCst);
-            CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
-            let elapsed_secs = if last_up > 0 {
-                (now.saturating_sub(last_up)) as f64 / 1_000_000.0
-            } else {
-                f64::MAX
-            };
-
-            if elapsed_secs < DOUBLE_TAP_WINDOW {
-                LAST_KEY_UP.store(0, Ordering::SeqCst);
-                CURRENT_PRESS_IS_DOUBLE_TAP.store(true, Ordering::SeqCst);
-                if let Ok(cb) = CALLBACKS.lock() {
-                    if let Some(ref f) = cb.on_double_tap {
-                        f();
-                    }
-                }
-            } else {
-                if let Ok(cb) = CALLBACKS.lock() {
-                    if let Some(ref f) = cb.on_key_down {
-                        f();
-                    }
-                }
+        if is_modifier_only {
+            if modifiers_active && !IS_HELD.load(Ordering::SeqCst) {
+                fire_key_down();
+                return std::ptr::null_mut();
+            } else if !modifiers_active && IS_HELD.load(Ordering::SeqCst) {
+                fire_key_up();
+                return std::ptr::null_mut();
             }
-
-            return std::ptr::null_mut(); // consume event
-        } else if !trigger_active && IS_HELD.load(Ordering::SeqCst) {
-            IS_HELD.store(false, Ordering::SeqCst);
-            let now = now_micros();
-            let down_at = KEY_DOWN_AT.swap(0, Ordering::SeqCst);
-            let held_secs = if down_at > 0 {
-                (now.saturating_sub(down_at)) as f64 / 1_000_000.0
-            } else {
-                f64::MAX
-            };
-            let was_double_tap = CURRENT_PRESS_IS_DOUBLE_TAP.swap(false, Ordering::SeqCst);
-
-            if !was_double_tap && held_secs <= MAX_TAP_DURATION {
-                LAST_KEY_UP.store(now, Ordering::SeqCst);
-            } else {
-                LAST_KEY_UP.store(0, Ordering::SeqCst);
-            }
-
-            if let Ok(cb) = CALLBACKS.lock() {
-                if let Some(ref f) = cb.on_key_up {
-                    f();
-                }
-            }
-
-            return std::ptr::null_mut(); // consume release too
+        } else if modifiers_active
+            && all_triggers_pressed(&trigger_keycodes)
+            && !IS_HELD.load(Ordering::SeqCst)
+        {
+            fire_key_down();
+            return std::ptr::null_mut();
+        } else if !modifiers_active && IS_HELD.load(Ordering::SeqCst) {
+            fire_key_up();
+            return std::ptr::null_mut();
         }
 
         event
+    }
+
+    enum CaptureAction {
+        Captured(String),
+        Consume,
+        Ignore,
+    }
+
+    unsafe fn capture_event(event_type: u32, event: CGEventRef) -> CaptureAction {
+        if event_type == K_CG_EVENT_FLAGS_CHANGED {
+            let flags = CGEventGetFlags(event) & ALL_MODIFIER_FLAGS;
+            let previous = CAPTURE_MODIFIER_FLAGS.swap(flags, Ordering::SeqCst);
+            let has_triggers = CAPTURE_TRIGGER_KEYCODES
+                .lock()
+                .ok()
+                .is_some_and(|triggers| !triggers.is_empty());
+
+            if flags == 0 {
+                if previous != 0 && !has_triggers {
+                    return CaptureAction::Captured(
+                        last_capture_shortcut()
+                            .unwrap_or_else(|| shortcut_from_parts(previous, &[])),
+                    );
+                }
+                return CaptureAction::Consume;
+            }
+
+            preview_current_capture();
+
+            return CaptureAction::Consume;
+        }
+
+        if event_type == K_CG_EVENT_KEY_DOWN || event_type == K_CG_EVENT_KEY_UP {
+            let keycode = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE);
+
+            if keycode == 63 || keycode == 179 {
+                return CaptureAction::Consume;
+            }
+
+            if event_type == K_CG_EVENT_KEY_DOWN {
+                if trigger_for_keycode(keycode).is_some() {
+                    mark_capture_trigger_pressed(keycode);
+                    preview_current_capture();
+                }
+                return CaptureAction::Consume;
+            }
+
+            if event_type == K_CG_EVENT_KEY_UP {
+                unmark_capture_trigger_pressed(keycode);
+                let flags = CGEventGetFlags(event) & ALL_MODIFIER_FLAGS;
+                let has_triggers = CAPTURE_TRIGGER_KEYCODES
+                    .lock()
+                    .ok()
+                    .is_some_and(|triggers| !triggers.is_empty());
+                if flags == 0 && !has_triggers {
+                    if let Some(shortcut) = last_capture_shortcut() {
+                        return CaptureAction::Captured(shortcut);
+                    }
+                }
+            }
+
+            return CaptureAction::Consume;
+        }
+
+        CaptureAction::Ignore
+    }
+
+    fn shortcut_from_parts(flags: u64, triggers: &[String]) -> String {
+        let mut parts = Vec::new();
+        if (flags & K_CG_EVENT_FLAG_MASK_COMMAND) != 0 {
+            parts.push("cmd");
+        }
+        if (flags & K_CG_EVENT_FLAG_MASK_CONTROL) != 0 {
+            parts.push("ctrl");
+        }
+        if (flags & K_CG_EVENT_FLAG_MASK_ALTERNATE) != 0 {
+            parts.push("option");
+        }
+        if (flags & K_CG_EVENT_FLAG_MASK_SHIFT) != 0 {
+            parts.push("shift");
+        }
+        if (flags & K_CG_EVENT_FLAG_MASK_SECONDARY_FN) != 0 {
+            parts.push("fn");
+        }
+        for trigger in triggers {
+            parts.push(trigger);
+        }
+
+        parts.join("+")
+    }
+
+    fn preview_current_capture() {
+        let shortcut = capture_shortcut();
+        if !shortcut.is_empty() {
+            if let Ok(mut last) = CAPTURE_LAST_SHORTCUT.lock() {
+                if *last == shortcut {
+                    return;
+                }
+                *last = shortcut.clone();
+            }
+            preview_capture(shortcut);
+        }
+    }
+
+    fn last_capture_shortcut() -> Option<String> {
+        CAPTURE_LAST_SHORTCUT
+            .lock()
+            .ok()
+            .map(|shortcut| shortcut.clone())
+            .filter(|shortcut| !shortcut.is_empty())
+    }
+
+    fn capture_shortcut() -> String {
+        let flags = CAPTURE_MODIFIER_FLAGS.load(Ordering::SeqCst);
+        let triggers = CAPTURE_TRIGGER_KEYCODES
+            .lock()
+            .ok()
+            .map(|keycodes| {
+                keycodes
+                    .iter()
+                    .filter_map(|keycode| trigger_for_keycode(*keycode))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        shortcut_from_parts(flags, &triggers)
+    }
+
+    fn mark_capture_trigger_pressed(keycode: i64) {
+        if let Ok(mut triggers) = CAPTURE_TRIGGER_KEYCODES.lock() {
+            if !triggers.contains(&keycode) {
+                triggers.push(keycode);
+            }
+        }
+    }
+
+    fn unmark_capture_trigger_pressed(keycode: i64) {
+        if let Ok(mut triggers) = CAPTURE_TRIGGER_KEYCODES.lock() {
+            triggers.retain(|trigger| *trigger != keycode);
+        }
+    }
+
+    fn fire_key_down() {
+        IS_HELD.store(true, Ordering::SeqCst);
+
+        let last_up = LAST_KEY_UP.load(Ordering::SeqCst);
+        let now = now_micros();
+        KEY_DOWN_AT.store(now, Ordering::SeqCst);
+        CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
+        let elapsed_secs = if last_up > 0 {
+            (now.saturating_sub(last_up)) as f64 / 1_000_000.0
+        } else {
+            f64::MAX
+        };
+
+        if elapsed_secs < DOUBLE_TAP_WINDOW {
+            LAST_KEY_UP.store(0, Ordering::SeqCst);
+            CURRENT_PRESS_IS_DOUBLE_TAP.store(true, Ordering::SeqCst);
+            if let Ok(cb) = CALLBACKS.lock() {
+                if let Some(ref f) = cb.on_double_tap {
+                    f();
+                }
+            }
+        } else if let Ok(cb) = CALLBACKS.lock() {
+            if let Some(ref f) = cb.on_key_down {
+                f();
+            }
+        }
+    }
+
+    fn fire_key_up() {
+        IS_HELD.store(false, Ordering::SeqCst);
+        let now = now_micros();
+        let down_at = KEY_DOWN_AT.swap(0, Ordering::SeqCst);
+        let held_secs = if down_at > 0 {
+            (now.saturating_sub(down_at)) as f64 / 1_000_000.0
+        } else {
+            f64::MAX
+        };
+        let was_double_tap = CURRENT_PRESS_IS_DOUBLE_TAP.swap(false, Ordering::SeqCst);
+
+        if !was_double_tap && held_secs <= MAX_TAP_DURATION {
+            LAST_KEY_UP.store(now, Ordering::SeqCst);
+        } else {
+            LAST_KEY_UP.store(0, Ordering::SeqCst);
+        }
+
+        if let Ok(cb) = CALLBACKS.lock() {
+            if let Some(ref f) = cb.on_key_up {
+                f();
+            }
+        }
+    }
+
+    fn modifiers_match(flags: u64, required: u64) -> bool {
+        (flags & ALL_MODIFIER_FLAGS) == required
+    }
+
+    fn mark_trigger_pressed(keycode: i64) {
+        if let Ok(mut pressed) = PRESSED_TRIGGER_KEYCODES.lock() {
+            if !pressed.contains(&keycode) {
+                pressed.push(keycode);
+            }
+        }
+    }
+
+    fn unmark_trigger_pressed(keycode: i64) {
+        if let Ok(mut pressed) = PRESSED_TRIGGER_KEYCODES.lock() {
+            pressed.retain(|pressed_keycode| *pressed_keycode != keycode);
+        }
+    }
+
+    fn all_triggers_pressed(trigger_keycodes: &[i64]) -> bool {
+        PRESSED_TRIGGER_KEYCODES.lock().ok().is_some_and(|pressed| {
+            trigger_keycodes
+                .iter()
+                .all(|keycode| pressed.contains(keycode))
+        })
+    }
+
+    fn modifier_flags(spec: &HotkeySpec) -> u64 {
+        spec.modifiers.iter().fold(0, |flags, modifier| {
+            flags
+                | match modifier {
+                    HotkeyModifier::Command => K_CG_EVENT_FLAG_MASK_COMMAND,
+                    HotkeyModifier::Control => K_CG_EVENT_FLAG_MASK_CONTROL,
+                    HotkeyModifier::Option => K_CG_EVENT_FLAG_MASK_ALTERNATE,
+                    HotkeyModifier::Shift => K_CG_EVENT_FLAG_MASK_SHIFT,
+                    HotkeyModifier::Fn => K_CG_EVENT_FLAG_MASK_SECONDARY_FN,
+                }
+        })
+    }
+
+    fn keycode_for_trigger(trigger: &str) -> Option<i64> {
+        if let Some(raw) = trigger.strip_prefix("keycode:") {
+            return raw.parse::<i64>().ok();
+        }
+
+        let keycode = match trigger {
+            "a" => 0,
+            "s" => 1,
+            "d" => 2,
+            "f" => 3,
+            "h" => 4,
+            "g" => 5,
+            "z" => 6,
+            "x" => 7,
+            "c" => 8,
+            "v" => 9,
+            "b" => 11,
+            "q" => 12,
+            "w" => 13,
+            "e" => 14,
+            "r" => 15,
+            "y" => 16,
+            "t" => 17,
+            "1" => 18,
+            "2" => 19,
+            "3" => 20,
+            "4" => 21,
+            "6" => 22,
+            "5" => 23,
+            "=" => 24,
+            "9" => 25,
+            "7" => 26,
+            "-" => 27,
+            "8" => 28,
+            "0" => 29,
+            "]" => 30,
+            "o" => 31,
+            "u" => 32,
+            "[" => 33,
+            "i" => 34,
+            "p" => 35,
+            "return" => 36,
+            "l" => 37,
+            "j" => 38,
+            "'" => 39,
+            "k" => 40,
+            ";" => 41,
+            "\\" => 42,
+            "," => 43,
+            "/" => 44,
+            "n" => 45,
+            "m" => 46,
+            "." => 47,
+            "tab" => 48,
+            "space" => 49,
+            "`" => 50,
+            "delete" => 51,
+            "escape" => 53,
+            "capslock" => 57,
+            "f17" => 64,
+            "f18" => 79,
+            "f19" => 80,
+            "f20" => 90,
+            "f5" => 96,
+            "f6" => 97,
+            "f7" => 98,
+            "f3" => 99,
+            "f8" => 100,
+            "f9" => 101,
+            "f11" => 103,
+            "f13" => 105,
+            "f16" => 106,
+            "f14" => 107,
+            "f10" => 109,
+            "f12" => 111,
+            "f15" => 113,
+            "home" => 115,
+            "pageup" => 116,
+            "forwarddelete" => 117,
+            "f4" => 118,
+            "end" => 119,
+            "f2" => 120,
+            "pagedown" => 121,
+            "f1" => 122,
+            "left" => 123,
+            "right" => 124,
+            "down" => 125,
+            "up" => 126,
+            _ => return None,
+        };
+
+        Some(keycode)
     }
 
     /// Remove the event tap and clean up.
@@ -376,6 +988,106 @@ mod platform {
         KEY_DOWN_AT.store(0, Ordering::SeqCst);
         CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
     }
+
+    pub fn reset_capture_state() {
+        CAPTURE_MODIFIER_FLAGS.store(0, Ordering::SeqCst);
+        if let Ok(mut triggers) = CAPTURE_TRIGGER_KEYCODES.lock() {
+            triggers.clear();
+        }
+        if let Ok(mut last) = CAPTURE_LAST_SHORTCUT.lock() {
+            last.clear();
+        }
+    }
+
+    fn trigger_for_keycode(keycode: i64) -> Option<String> {
+        let trigger = match keycode {
+            0 => "a",
+            1 => "s",
+            2 => "d",
+            3 => "f",
+            4 => "h",
+            5 => "g",
+            6 => "z",
+            7 => "x",
+            8 => "c",
+            9 => "v",
+            11 => "b",
+            12 => "q",
+            13 => "w",
+            14 => "e",
+            15 => "r",
+            16 => "y",
+            17 => "t",
+            18 => "1",
+            19 => "2",
+            20 => "3",
+            21 => "4",
+            22 => "6",
+            23 => "5",
+            24 => "=",
+            25 => "9",
+            26 => "7",
+            27 => "-",
+            28 => "8",
+            29 => "0",
+            30 => "]",
+            31 => "o",
+            32 => "u",
+            33 => "[",
+            34 => "i",
+            35 => "p",
+            36 => "return",
+            37 => "l",
+            38 => "j",
+            39 => "'",
+            40 => "k",
+            41 => ";",
+            42 => "\\",
+            43 => ",",
+            44 => "/",
+            45 => "n",
+            46 => "m",
+            47 => ".",
+            48 => "tab",
+            49 => "space",
+            50 => "`",
+            51 => "delete",
+            53 => "escape",
+            57 => "capslock",
+            64 => "f17",
+            79 => "f18",
+            80 => "f19",
+            90 => "f20",
+            96 => "f5",
+            97 => "f6",
+            98 => "f7",
+            99 => "f3",
+            100 => "f8",
+            101 => "f9",
+            103 => "f11",
+            105 => "f13",
+            106 => "f16",
+            107 => "f14",
+            109 => "f10",
+            111 => "f12",
+            113 => "f15",
+            115 => "home",
+            116 => "pageup",
+            117 => "forwarddelete",
+            118 => "f4",
+            119 => "end",
+            120 => "f2",
+            121 => "pagedown",
+            122 => "f1",
+            123 => "left",
+            124 => "right",
+            125 => "down",
+            126 => "up",
+            _ => return Some(format!("keycode:{keycode}")),
+        };
+
+        Some(trigger.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -389,8 +1101,8 @@ mod platform {
     use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
     use windows::Win32::UI::WindowsAndMessaging::{
         CallNextHookEx, DispatchMessageW, GetMessageW, PostThreadMessageW, SetWindowsHookExW,
-        TranslateMessage, UnhookWindowsHookEx, KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL,
-        WM_KEYDOWN, WM_KEYUP, WM_QUIT, WM_SYSKEYDOWN, WM_SYSKEYUP,
+        TranslateMessage, UnhookWindowsHookEx, KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL, WM_KEYDOWN,
+        WM_KEYUP, WM_QUIT, WM_SYSKEYDOWN, WM_SYSKEYUP,
     };
 
     /// Track key held state.
@@ -405,8 +1117,28 @@ mod platform {
     /// Whether the current held key press already fired the double-tap callback.
     static CURRENT_PRESS_IS_DOUBLE_TAP: AtomicBool = AtomicBool::new(false);
 
-    /// The virtual key code we're monitoring (default: CapsLock = 0x14).
-    static TARGET_VK: Mutex<u16> = Mutex::new(0x14);
+    /// Required modifiers for the configured shortcut.
+    static REQUIRED_MODIFIERS: AtomicU64 = AtomicU64::new(0);
+
+    /// Currently pressed modifiers observed by the keyboard hook.
+    static PRESSED_MODIFIERS: AtomicU64 = AtomicU64::new(0);
+
+    /// Last modifier-only candidate observed while native shortcut capture is active.
+    static CAPTURE_MODIFIERS: AtomicU64 = AtomicU64::new(0);
+
+    /// The configured non-modifier virtual key codes. Empty means modifier-only.
+    static TARGET_VKS: once_cell::sync::Lazy<Mutex<Vec<u16>>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+    /// Currently held configured non-modifier virtual key codes.
+    static PRESSED_TARGET_VKS: once_cell::sync::Lazy<Mutex<Vec<u16>>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+    static CAPTURE_TARGET_VKS: once_cell::sync::Lazy<Mutex<Vec<u16>>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+    static CAPTURE_LAST_SHORTCUT: once_cell::sync::Lazy<Mutex<String>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(String::new()));
 
     /// Thread ID of the hook thread (for PostThreadMessageW).
     static HOOK_THREAD_ID: AtomicU64 = AtomicU64::new(0);
@@ -418,20 +1150,30 @@ mod platform {
             .as_micros() as u64
     }
 
+    const MOD_COMMAND: u64 = 1 << 0;
+    const MOD_CONTROL: u64 = 1 << 1;
+    const MOD_OPTION: u64 = 1 << 2;
+    const MOD_SHIFT: u64 = 1 << 3;
+    const MOD_FN: u64 = 1 << 4;
+
     /// Install a low-level keyboard hook (WH_KEYBOARD_LL).
-    pub fn start(modifier: HotkeyModifier) {
+    pub fn start(spec: HotkeySpec) {
         if RUNNING.swap(true, Ordering::SeqCst) {
             return;
         }
 
-        // Map modifier to VK code
-        let vk = match modifier {
-            HotkeyModifier::Fn => 0x14u16,    // CapsLock as fn equivalent on Windows
-            HotkeyModifier::Option => 0xA4u16, // VK_LMENU (Left Alt)
-        };
-        if let Ok(mut target) = TARGET_VK.lock() {
-            *target = vk;
+        if let Ok(mut targets) = TARGET_VKS.lock() {
+            *targets = spec
+                .triggers
+                .iter()
+                .filter_map(|trigger| vk_for_trigger(trigger))
+                .collect();
         }
+        if let Ok(mut pressed) = PRESSED_TARGET_VKS.lock() {
+            pressed.clear();
+        }
+        REQUIRED_MODIFIERS.store(modifier_bits(&spec), Ordering::SeqCst);
+        PRESSED_MODIFIERS.store(0, Ordering::SeqCst);
         IS_HELD.store(false, Ordering::SeqCst);
         LAST_KEY_UP.store(0, Ordering::SeqCst);
         KEY_DOWN_AT.store(0, Ordering::SeqCst);
@@ -490,73 +1232,392 @@ mod platform {
 
         let kb = *(l_param.0 as *const KBDLLHOOKSTRUCT);
         let vk_code = kb.vkCode as u16;
-        let target = TARGET_VK.lock().ok().map(|t| *t).unwrap_or(0x14);
-
-        if vk_code != target {
-            return CallNextHookEx(None, n_code, w_param, l_param);
-        }
-
         let msg = w_param.0 as u32;
         let is_key_down = msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN;
         let is_key_up = msg == WM_KEYUP || msg == WM_SYSKEYUP;
+        let targets = TARGET_VKS
+            .lock()
+            .ok()
+            .map(|targets| targets.clone())
+            .unwrap_or_default();
+        let is_modifier_only = targets.is_empty();
 
-        if is_key_down && !IS_HELD.load(Ordering::SeqCst) {
-            IS_HELD.store(true, Ordering::SeqCst);
-
-            let last_up = LAST_KEY_UP.load(Ordering::SeqCst);
-            let now = now_micros();
-            KEY_DOWN_AT.store(now, Ordering::SeqCst);
-            CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
-            let elapsed_secs = if last_up > 0 {
-                (now.saturating_sub(last_up)) as f64 / 1_000_000.0
-            } else {
-                f64::MAX
-            };
-
-            if elapsed_secs < DOUBLE_TAP_WINDOW {
-                LAST_KEY_UP.store(0, Ordering::SeqCst);
-                CURRENT_PRESS_IS_DOUBLE_TAP.store(true, Ordering::SeqCst);
-                if let Ok(cb) = CALLBACKS.lock() {
-                    if let Some(ref f) = cb.on_double_tap {
-                        f();
-                    }
+        if is_capturing() {
+            match capture_event(vk_code, is_key_down, is_key_up) {
+                CaptureAction::Captured(shortcut) => {
+                    finish_capture(shortcut);
+                    return LRESULT(1);
                 }
-            } else {
-                if let Ok(cb) = CALLBACKS.lock() {
-                    if let Some(ref f) = cb.on_key_down {
-                        f();
-                    }
-                }
+                CaptureAction::Consume => return LRESULT(1),
+                CaptureAction::Ignore => {}
+            }
+        }
+
+        if let Some(modifier) = modifier_bit_for_vk(vk_code) {
+            if is_key_down {
+                PRESSED_MODIFIERS.fetch_or(modifier, Ordering::SeqCst);
+            } else if is_key_up {
+                PRESSED_MODIFIERS.fetch_and(!modifier, Ordering::SeqCst);
             }
 
-            return LRESULT(1); // consume event
+            let modifiers_active = modifiers_match();
+            if is_modifier_only {
+                if modifiers_active && !IS_HELD.load(Ordering::SeqCst) {
+                    fire_key_down();
+                    return LRESULT(1);
+                } else if !modifiers_active && IS_HELD.load(Ordering::SeqCst) {
+                    fire_key_up();
+                    return LRESULT(1);
+                }
+            } else if modifiers_active
+                && all_targets_pressed(&targets)
+                && !IS_HELD.load(Ordering::SeqCst)
+            {
+                fire_key_down();
+                return LRESULT(1);
+            } else if !modifiers_active && IS_HELD.load(Ordering::SeqCst) {
+                fire_key_up();
+                return LRESULT(1);
+            }
+
+            return CallNextHookEx(None, n_code, w_param, l_param);
+        }
+
+        if is_modifier_only || !targets.contains(&vk_code) {
+            return CallNextHookEx(None, n_code, w_param, l_param);
+        }
+
+        if is_key_down {
+            mark_target_pressed(vk_code);
+            if modifiers_match() && all_targets_pressed(&targets) && !IS_HELD.load(Ordering::SeqCst)
+            {
+                fire_key_down();
+            }
+            if IS_HELD.load(Ordering::SeqCst) {
+                return LRESULT(1);
+            }
         } else if is_key_up && IS_HELD.load(Ordering::SeqCst) {
-            IS_HELD.store(false, Ordering::SeqCst);
-            let now = now_micros();
-            let down_at = KEY_DOWN_AT.swap(0, Ordering::SeqCst);
-            let held_secs = if down_at > 0 {
-                (now.saturating_sub(down_at)) as f64 / 1_000_000.0
-            } else {
-                f64::MAX
-            };
-            let was_double_tap = CURRENT_PRESS_IS_DOUBLE_TAP.swap(false, Ordering::SeqCst);
-
-            if !was_double_tap && held_secs <= MAX_TAP_DURATION {
-                LAST_KEY_UP.store(now, Ordering::SeqCst);
-            } else {
-                LAST_KEY_UP.store(0, Ordering::SeqCst);
-            }
-
-            if let Ok(cb) = CALLBACKS.lock() {
-                if let Some(ref f) = cb.on_key_up {
-                    f();
-                }
-            }
-
-            return LRESULT(1); // consume release too
+            unmark_target_pressed(vk_code);
+            fire_key_up();
+            return LRESULT(1);
+        } else if is_key_up {
+            unmark_target_pressed(vk_code);
         }
 
         CallNextHookEx(None, n_code, w_param, l_param)
+    }
+
+    enum CaptureAction {
+        Captured(String),
+        Consume,
+        Ignore,
+    }
+
+    fn capture_event(vk_code: u16, is_key_down: bool, is_key_up: bool) -> CaptureAction {
+        if let Some(modifier) = modifier_bit_for_vk(vk_code) {
+            if is_key_down {
+                CAPTURE_MODIFIERS.fetch_or(modifier, Ordering::SeqCst);
+                preview_current_capture();
+                return CaptureAction::Consume;
+            }
+
+            if is_key_up {
+                let previous = CAPTURE_MODIFIERS.load(Ordering::SeqCst);
+                CAPTURE_MODIFIERS.fetch_and(!modifier, Ordering::SeqCst);
+                let has_triggers = CAPTURE_TARGET_VKS
+                    .lock()
+                    .ok()
+                    .is_some_and(|targets| !targets.is_empty());
+                if previous != 0 && !has_triggers {
+                    return CaptureAction::Captured(
+                        last_capture_shortcut()
+                            .unwrap_or_else(|| shortcut_from_parts(previous, &[])),
+                    );
+                }
+                return CaptureAction::Consume;
+            }
+        }
+
+        if is_key_down {
+            if trigger_for_vk(vk_code).is_some() {
+                mark_capture_target_pressed(vk_code);
+                preview_current_capture();
+            }
+            return CaptureAction::Consume;
+        }
+
+        if is_key_up {
+            unmark_capture_target_pressed(vk_code);
+            let modifiers = CAPTURE_MODIFIERS.load(Ordering::SeqCst);
+            let has_triggers = CAPTURE_TARGET_VKS
+                .lock()
+                .ok()
+                .is_some_and(|targets| !targets.is_empty());
+            if modifiers == 0 && !has_triggers {
+                if let Some(shortcut) = last_capture_shortcut() {
+                    return CaptureAction::Captured(shortcut);
+                }
+            }
+            return CaptureAction::Consume;
+        }
+
+        CaptureAction::Ignore
+    }
+
+    fn shortcut_from_parts(modifiers: u64, triggers: &[String]) -> String {
+        let mut parts = Vec::new();
+        if (modifiers & MOD_COMMAND) != 0 {
+            parts.push("cmd");
+        }
+        if (modifiers & MOD_CONTROL) != 0 {
+            parts.push("ctrl");
+        }
+        if (modifiers & MOD_OPTION) != 0 {
+            parts.push("option");
+        }
+        if (modifiers & MOD_SHIFT) != 0 {
+            parts.push("shift");
+        }
+        if (modifiers & MOD_FN) != 0 {
+            parts.push("fn");
+        }
+        for trigger in triggers {
+            parts.push(trigger);
+        }
+
+        parts.join("+")
+    }
+
+    fn preview_current_capture() {
+        let shortcut = capture_shortcut();
+        if !shortcut.is_empty() {
+            if let Ok(mut last) = CAPTURE_LAST_SHORTCUT.lock() {
+                if *last == shortcut {
+                    return;
+                }
+                *last = shortcut.clone();
+            }
+            preview_capture(shortcut);
+        }
+    }
+
+    fn last_capture_shortcut() -> Option<String> {
+        CAPTURE_LAST_SHORTCUT
+            .lock()
+            .ok()
+            .map(|shortcut| shortcut.clone())
+            .filter(|shortcut| !shortcut.is_empty())
+    }
+
+    fn capture_shortcut() -> String {
+        let modifiers = CAPTURE_MODIFIERS.load(Ordering::SeqCst);
+        let triggers = CAPTURE_TARGET_VKS
+            .lock()
+            .ok()
+            .map(|targets| {
+                targets
+                    .iter()
+                    .filter_map(|vk| trigger_for_vk(*vk))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        shortcut_from_parts(modifiers, &triggers)
+    }
+
+    fn mark_capture_target_pressed(vk: u16) {
+        if let Ok(mut targets) = CAPTURE_TARGET_VKS.lock() {
+            if !targets.contains(&vk) {
+                targets.push(vk);
+            }
+        }
+    }
+
+    fn unmark_capture_target_pressed(vk: u16) {
+        if let Ok(mut targets) = CAPTURE_TARGET_VKS.lock() {
+            targets.retain(|target| *target != vk);
+        }
+    }
+
+    fn fire_key_down() {
+        IS_HELD.store(true, Ordering::SeqCst);
+
+        let last_up = LAST_KEY_UP.load(Ordering::SeqCst);
+        let now = now_micros();
+        KEY_DOWN_AT.store(now, Ordering::SeqCst);
+        CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
+        let elapsed_secs = if last_up > 0 {
+            (now.saturating_sub(last_up)) as f64 / 1_000_000.0
+        } else {
+            f64::MAX
+        };
+
+        if elapsed_secs < DOUBLE_TAP_WINDOW {
+            LAST_KEY_UP.store(0, Ordering::SeqCst);
+            CURRENT_PRESS_IS_DOUBLE_TAP.store(true, Ordering::SeqCst);
+            if let Ok(cb) = CALLBACKS.lock() {
+                if let Some(ref f) = cb.on_double_tap {
+                    f();
+                }
+            }
+        } else if let Ok(cb) = CALLBACKS.lock() {
+            if let Some(ref f) = cb.on_key_down {
+                f();
+            }
+        }
+    }
+
+    fn fire_key_up() {
+        IS_HELD.store(false, Ordering::SeqCst);
+        let now = now_micros();
+        let down_at = KEY_DOWN_AT.swap(0, Ordering::SeqCst);
+        let held_secs = if down_at > 0 {
+            (now.saturating_sub(down_at)) as f64 / 1_000_000.0
+        } else {
+            f64::MAX
+        };
+        let was_double_tap = CURRENT_PRESS_IS_DOUBLE_TAP.swap(false, Ordering::SeqCst);
+
+        if !was_double_tap && held_secs <= MAX_TAP_DURATION {
+            LAST_KEY_UP.store(now, Ordering::SeqCst);
+        } else {
+            LAST_KEY_UP.store(0, Ordering::SeqCst);
+        }
+
+        if let Ok(cb) = CALLBACKS.lock() {
+            if let Some(ref f) = cb.on_key_up {
+                f();
+            }
+        }
+    }
+
+    fn modifiers_match() -> bool {
+        PRESSED_MODIFIERS.load(Ordering::SeqCst) == REQUIRED_MODIFIERS.load(Ordering::SeqCst)
+    }
+
+    fn mark_target_pressed(vk: u16) {
+        if let Ok(mut pressed) = PRESSED_TARGET_VKS.lock() {
+            if !pressed.contains(&vk) {
+                pressed.push(vk);
+            }
+        }
+    }
+
+    fn unmark_target_pressed(vk: u16) {
+        if let Ok(mut pressed) = PRESSED_TARGET_VKS.lock() {
+            pressed.retain(|pressed_vk| *pressed_vk != vk);
+        }
+    }
+
+    fn all_targets_pressed(targets: &[u16]) -> bool {
+        PRESSED_TARGET_VKS
+            .lock()
+            .ok()
+            .is_some_and(|pressed| targets.iter().all(|target| pressed.contains(target)))
+    }
+
+    fn modifier_bits(spec: &HotkeySpec) -> u64 {
+        spec.modifiers.iter().fold(0, |bits, modifier| {
+            bits | match modifier {
+                HotkeyModifier::Command => MOD_COMMAND,
+                HotkeyModifier::Control => MOD_CONTROL,
+                HotkeyModifier::Option => MOD_OPTION,
+                HotkeyModifier::Shift => MOD_SHIFT,
+                HotkeyModifier::Fn => MOD_FN,
+            }
+        })
+    }
+
+    fn modifier_bit_for_vk(vk: u16) -> Option<u64> {
+        match vk {
+            0x5B | 0x5C => Some(MOD_COMMAND), // Windows keys
+            0x11 | 0xA2 | 0xA3 => Some(MOD_CONTROL),
+            0x12 | 0xA4 | 0xA5 => Some(MOD_OPTION),
+            0x10 | 0xA0 | 0xA1 => Some(MOD_SHIFT),
+            0x14 => Some(MOD_FN), // CapsLock as fn equivalent on Windows
+            _ => None,
+        }
+    }
+
+    fn vk_for_trigger(trigger: &str) -> Option<u16> {
+        if let Some(raw) = trigger.strip_prefix("vk:") {
+            return raw.parse::<u16>().ok();
+        }
+
+        let vk = match trigger {
+            "a" => 0x41,
+            "b" => 0x42,
+            "c" => 0x43,
+            "d" => 0x44,
+            "e" => 0x45,
+            "f" => 0x46,
+            "g" => 0x47,
+            "h" => 0x48,
+            "i" => 0x49,
+            "j" => 0x4A,
+            "k" => 0x4B,
+            "l" => 0x4C,
+            "m" => 0x4D,
+            "n" => 0x4E,
+            "o" => 0x4F,
+            "p" => 0x50,
+            "q" => 0x51,
+            "r" => 0x52,
+            "s" => 0x53,
+            "t" => 0x54,
+            "u" => 0x55,
+            "v" => 0x56,
+            "w" => 0x57,
+            "x" => 0x58,
+            "y" => 0x59,
+            "z" => 0x5A,
+            "0" => 0x30,
+            "1" => 0x31,
+            "2" => 0x32,
+            "3" => 0x33,
+            "4" => 0x34,
+            "5" => 0x35,
+            "6" => 0x36,
+            "7" => 0x37,
+            "8" => 0x38,
+            "9" => 0x39,
+            "space" => 0x20,
+            "tab" => 0x09,
+            "return" => 0x0D,
+            "escape" => 0x1B,
+            "delete" => 0x08,
+            "forwarddelete" => 0x2E,
+            "capslock" => 0x14,
+            "left" => 0x25,
+            "up" => 0x26,
+            "right" => 0x27,
+            "down" => 0x28,
+            "home" => 0x24,
+            "end" => 0x23,
+            "pageup" => 0x21,
+            "pagedown" => 0x22,
+            ";" => 0xBA,
+            "=" => 0xBB,
+            "," => 0xBC,
+            "-" => 0xBD,
+            "." => 0xBE,
+            "/" => 0xBF,
+            "`" => 0xC0,
+            "[" => 0xDB,
+            "\\" => 0xDC,
+            "]" => 0xDD,
+            "'" => 0xDE,
+            _ if trigger.starts_with('f') => {
+                let n = trigger[1..].parse::<u16>().ok()?;
+                if (1..=20).contains(&n) {
+                    0x70 + n - 1
+                } else {
+                    return None;
+                }
+            }
+            _ => return None,
+        };
+
+        Some(vk)
     }
 
     /// Remove the keyboard hook.
@@ -578,15 +1639,115 @@ mod platform {
         KEY_DOWN_AT.store(0, Ordering::SeqCst);
         CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
     }
+
+    pub fn reset_capture_state() {
+        CAPTURE_MODIFIERS.store(0, Ordering::SeqCst);
+        if let Ok(mut targets) = CAPTURE_TARGET_VKS.lock() {
+            targets.clear();
+        }
+        if let Ok(mut last) = CAPTURE_LAST_SHORTCUT.lock() {
+            last.clear();
+        }
+    }
+
+    fn trigger_for_vk(vk: u16) -> Option<String> {
+        let trigger = match vk {
+            0x41 => "a",
+            0x42 => "b",
+            0x43 => "c",
+            0x44 => "d",
+            0x45 => "e",
+            0x46 => "f",
+            0x47 => "g",
+            0x48 => "h",
+            0x49 => "i",
+            0x4A => "j",
+            0x4B => "k",
+            0x4C => "l",
+            0x4D => "m",
+            0x4E => "n",
+            0x4F => "o",
+            0x50 => "p",
+            0x51 => "q",
+            0x52 => "r",
+            0x53 => "s",
+            0x54 => "t",
+            0x55 => "u",
+            0x56 => "v",
+            0x57 => "w",
+            0x58 => "x",
+            0x59 => "y",
+            0x5A => "z",
+            0x30 => "0",
+            0x31 => "1",
+            0x32 => "2",
+            0x33 => "3",
+            0x34 => "4",
+            0x35 => "5",
+            0x36 => "6",
+            0x37 => "7",
+            0x38 => "8",
+            0x39 => "9",
+            0x20 => "space",
+            0x09 => "tab",
+            0x0D => "return",
+            0x1B => "escape",
+            0x08 => "delete",
+            0x2E => "forwarddelete",
+            0x14 => "capslock",
+            0x25 => "left",
+            0x26 => "up",
+            0x27 => "right",
+            0x28 => "down",
+            0x24 => "home",
+            0x23 => "end",
+            0x21 => "pageup",
+            0x22 => "pagedown",
+            0xBA => ";",
+            0xBB => "=",
+            0xBC => ",",
+            0xBD => "-",
+            0xBE => ".",
+            0xBF => "/",
+            0xC0 => "`",
+            0xDB => "[",
+            0xDC => "\\",
+            0xDD => "]",
+            0xDE => "'",
+            0x70 => "f1",
+            0x71 => "f2",
+            0x72 => "f3",
+            0x73 => "f4",
+            0x74 => "f5",
+            0x75 => "f6",
+            0x76 => "f7",
+            0x77 => "f8",
+            0x78 => "f9",
+            0x79 => "f10",
+            0x7A => "f11",
+            0x7B => "f12",
+            0x7C => "f13",
+            0x7D => "f14",
+            0x7E => "f15",
+            0x7F => "f16",
+            0x80 => "f17",
+            0x81 => "f18",
+            0x82 => "f19",
+            0x83 => "f20",
+            _ => return Some(format!("vk:{vk}")),
+        };
+
+        Some(trigger.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Public API (delegates to platform)
 // ---------------------------------------------------------------------------
 
-/// Begin listening for the hotkey modifier. Safe to call multiple times.
-pub fn start(modifier: HotkeyModifier) {
-    platform::start(modifier);
+/// Begin listening for the hotkey shortcut. Safe to call multiple times.
+pub fn start(spec: HotkeySpec) {
+    platform::start(spec);
 }
 
 /// Stop listening. Safe to call when already stopped.

--- a/tauri-app/src-tauri/src/hotkey.rs
+++ b/tauri-app/src-tauri/src/hotkey.rs
@@ -1,10 +1,11 @@
 // This module is a public API; many items are not yet wired into commands.
 #![allow(dead_code)]
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{mpsc, Mutex};
 
 static RUNNING: AtomicBool = AtomicBool::new(false);
+static LISTENER_EPOCH: AtomicU64 = AtomicU64::new(0);
 
 /// Callback type for hotkey events.
 type HotkeyCallback = Box<dyn Fn() + Send + 'static>;
@@ -36,6 +37,76 @@ unsafe impl Send for HotkeyCallbacks {}
 struct CaptureCallbacks {
     on_preview: CaptureCallback,
     on_capture: CaptureCallback,
+}
+
+enum RuntimeEvent {
+    KeyDown,
+    KeyUp,
+    DoubleTap,
+    CapturePreview(String),
+    CaptureFinish(CaptureCallback, String),
+}
+
+static DISPATCHER: once_cell::sync::Lazy<mpsc::Sender<RuntimeEvent>> =
+    once_cell::sync::Lazy::new(|| {
+        let (tx, rx) = mpsc::channel::<RuntimeEvent>();
+        std::thread::Builder::new()
+            .name("yap-hotkey-dispatch".into())
+            .spawn(move || {
+                while let Ok(event) = rx.recv() {
+                    match event {
+                        RuntimeEvent::KeyDown => {
+                            if let Ok(cb) = CALLBACKS.lock() {
+                                if let Some(ref f) = cb.on_key_down {
+                                    f();
+                                }
+                            }
+                        }
+                        RuntimeEvent::KeyUp => {
+                            if let Ok(cb) = CALLBACKS.lock() {
+                                if let Some(ref f) = cb.on_key_up {
+                                    f();
+                                }
+                            }
+                        }
+                        RuntimeEvent::DoubleTap => {
+                            if let Ok(cb) = CALLBACKS.lock() {
+                                if let Some(ref f) = cb.on_double_tap {
+                                    f();
+                                }
+                            }
+                        }
+                        RuntimeEvent::CapturePreview(shortcut) => {
+                            if let Ok(capture) = CAPTURE_CALLBACKS.lock() {
+                                if let Some(callbacks) = capture.as_ref() {
+                                    (callbacks.on_preview)(shortcut);
+                                }
+                            }
+                        }
+                        RuntimeEvent::CaptureFinish(callback, shortcut) => {
+                            callback(shortcut);
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn hotkey dispatch thread");
+        tx
+    });
+
+fn dispatch(event: RuntimeEvent) {
+    let _ = DISPATCHER.send(event);
+}
+
+fn begin_listener_generation() -> u64 {
+    LISTENER_EPOCH.fetch_add(1, Ordering::SeqCst) + 1
+}
+
+fn cancel_listener_generation() {
+    LISTENER_EPOCH.fetch_add(1, Ordering::SeqCst);
+}
+
+fn listener_generation_matches(generation: u64) -> bool {
+    RUNNING.load(Ordering::SeqCst) && LISTENER_EPOCH.load(Ordering::SeqCst) == generation
 }
 
 /// Modifier keys supported in configurable shortcuts.
@@ -188,7 +259,7 @@ fn normalize_key(value: &str) -> Option<String> {
             && value[1..]
                 .parse::<u8>()
                 .ok()
-                .is_some_and(|n| (1..=20).contains(&n)) =>
+                .is_some_and(|n| (1..=24).contains(&n)) =>
         {
             value
         }
@@ -290,11 +361,7 @@ fn is_capturing() -> bool {
 }
 
 fn preview_capture(shortcut: String) {
-    if let Ok(capture) = CAPTURE_CALLBACKS.lock() {
-        if let Some(callbacks) = capture.as_ref() {
-            (callbacks.on_preview)(shortcut);
-        }
-    }
+    dispatch(RuntimeEvent::CapturePreview(shortcut));
 }
 
 fn finish_capture(shortcut: String) {
@@ -307,7 +374,7 @@ fn finish_capture(shortcut: String) {
     platform::reset_capture_state();
 
     if let Some(callback) = callback {
-        callback(shortcut);
+        dispatch(RuntimeEvent::CaptureFinish(callback, shortcut));
     }
 }
 
@@ -460,13 +527,23 @@ mod platform {
             return; // already running
         }
 
+        let trigger_keycodes = spec
+            .triggers
+            .iter()
+            .filter_map(|trigger| keycode_for_trigger(trigger))
+            .collect::<Vec<_>>();
+        if trigger_keycodes.len() != spec.triggers.len() {
+            eprintln!(
+                "[yap] HOTKEY FAILED: unsupported macOS shortcut {}",
+                spec.label()
+            );
+            RUNNING.store(false, Ordering::SeqCst);
+            return;
+        }
+
         REQUIRED_MODIFIER_FLAGS.store(modifier_flags(&spec), Ordering::SeqCst);
         if let Ok(mut triggers) = TRIGGER_KEYCODES.lock() {
-            *triggers = spec
-                .triggers
-                .iter()
-                .filter_map(|trigger| keycode_for_trigger(trigger))
-                .collect();
+            *triggers = trigger_keycodes;
         }
         if let Ok(mut pressed) = PRESSED_TRIGGER_KEYCODES.lock() {
             pressed.clear();
@@ -475,6 +552,7 @@ mod platform {
         LAST_KEY_UP.store(0, Ordering::SeqCst);
         KEY_DOWN_AT.store(0, Ordering::SeqCst);
         CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
+        let generation = begin_listener_generation();
 
         // Spawn a dedicated thread with its own CFRunLoop
         std::thread::Builder::new()
@@ -527,7 +605,7 @@ mod platform {
                     // Run the loop until stopped.
                     // MUST use kCFRunLoopDefaultMode here (not CommonModes — that's
                     // only valid for AddSource, not RunInMode).
-                    while RUNNING.load(Ordering::SeqCst) {
+                    while listener_generation_matches(generation) {
                         CFRunLoopRunInMode(
                             kCFRunLoopDefaultMode,
                             0.25, // check every 250ms if we should stop
@@ -805,15 +883,9 @@ mod platform {
         if elapsed_secs < DOUBLE_TAP_WINDOW {
             LAST_KEY_UP.store(0, Ordering::SeqCst);
             CURRENT_PRESS_IS_DOUBLE_TAP.store(true, Ordering::SeqCst);
-            if let Ok(cb) = CALLBACKS.lock() {
-                if let Some(ref f) = cb.on_double_tap {
-                    f();
-                }
-            }
-        } else if let Ok(cb) = CALLBACKS.lock() {
-            if let Some(ref f) = cb.on_key_down {
-                f();
-            }
+            dispatch(RuntimeEvent::DoubleTap);
+        } else {
+            dispatch(RuntimeEvent::KeyDown);
         }
     }
 
@@ -834,11 +906,7 @@ mod platform {
             LAST_KEY_UP.store(0, Ordering::SeqCst);
         }
 
-        if let Ok(cb) = CALLBACKS.lock() {
-            if let Some(ref f) = cb.on_key_up {
-                f();
-            }
-        }
+        dispatch(RuntimeEvent::KeyUp);
     }
 
     fn modifiers_match(flags: u64, required: u64) -> bool {
@@ -976,6 +1044,7 @@ mod platform {
 
     /// Remove the event tap and clean up.
     pub fn stop() {
+        cancel_listener_generation();
         if !RUNNING.swap(false, Ordering::SeqCst) {
             return; // not running
         }
@@ -1154,17 +1223,35 @@ mod platform {
     const MOD_CONTROL: u64 = 1 << 1;
     const MOD_OPTION: u64 = 1 << 2;
     const MOD_SHIFT: u64 = 1 << 3;
+    const WINDOWS_FN_VK: u16 = 0x87; // VK_F24; common Windows stand-in for Fn/Globe.
+
     /// Install a low-level keyboard hook (WH_KEYBOARD_LL).
     pub fn start(spec: HotkeySpec) {
         if RUNNING.swap(true, Ordering::SeqCst) {
             return;
         }
 
-        let target_vks = spec
+        let mut target_vks = spec
             .triggers
             .iter()
             .filter_map(|trigger| vk_for_trigger(trigger))
             .collect::<Vec<_>>();
+        if target_vks.len() != spec.triggers.len() {
+            eprintln!(
+                "[yap] HOTKEY FAILED: unsupported Windows shortcut {}",
+                spec.label()
+            );
+            RUNNING.store(false, Ordering::SeqCst);
+            return;
+        }
+
+        // Windows does not expose laptop Fn keys consistently. Keyboards that
+        // do expose a user-space Fn/Globe-style key commonly report VK_F24.
+        // Treat configured `fn` as that physical target, not as a zero-bit
+        // modifier, so `fn` and `fn+key` can produce real down/up events.
+        if spec.modifiers.contains(&HotkeyModifier::Fn) && !target_vks.contains(&WINDOWS_FN_VK) {
+            target_vks.insert(0, WINDOWS_FN_VK);
+        }
 
         if let Ok(mut targets) = TARGET_VKS.lock() {
             *targets = target_vks;
@@ -1178,6 +1265,7 @@ mod platform {
         LAST_KEY_UP.store(0, Ordering::SeqCst);
         KEY_DOWN_AT.store(0, Ordering::SeqCst);
         CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
+        let generation = begin_listener_generation();
 
         std::thread::Builder::new()
             .name("yap-hotkey".into())
@@ -1202,7 +1290,7 @@ mod platform {
 
                     // Message pump
                     let mut msg = MSG::default();
-                    while RUNNING.load(Ordering::SeqCst) {
+                    while listener_generation_matches(generation) {
                         let ret = GetMessageW(&mut msg, None, 0, 0);
                         if ret.0 <= 0 {
                             break;
@@ -1451,15 +1539,9 @@ mod platform {
         if elapsed_secs < DOUBLE_TAP_WINDOW {
             LAST_KEY_UP.store(0, Ordering::SeqCst);
             CURRENT_PRESS_IS_DOUBLE_TAP.store(true, Ordering::SeqCst);
-            if let Ok(cb) = CALLBACKS.lock() {
-                if let Some(ref f) = cb.on_double_tap {
-                    f();
-                }
-            }
-        } else if let Ok(cb) = CALLBACKS.lock() {
-            if let Some(ref f) = cb.on_key_down {
-                f();
-            }
+            dispatch(RuntimeEvent::DoubleTap);
+        } else {
+            dispatch(RuntimeEvent::KeyDown);
         }
     }
 
@@ -1480,11 +1562,7 @@ mod platform {
             LAST_KEY_UP.store(0, Ordering::SeqCst);
         }
 
-        if let Ok(cb) = CALLBACKS.lock() {
-            if let Some(ref f) = cb.on_key_up {
-                f();
-            }
-        }
+        dispatch(RuntimeEvent::KeyUp);
     }
 
     fn modifiers_match() -> bool {
@@ -1604,7 +1682,7 @@ mod platform {
             "'" => 0xDE,
             _ if trigger.starts_with('f') => {
                 let n = trigger[1..].parse::<u16>().ok()?;
-                if (1..=20).contains(&n) {
+                if (1..=24).contains(&n) {
                     0x70 + n - 1
                 } else {
                     return None;
@@ -1618,6 +1696,7 @@ mod platform {
 
     /// Remove the keyboard hook.
     pub fn stop() {
+        cancel_listener_generation();
         if !RUNNING.swap(false, Ordering::SeqCst) {
             return;
         }
@@ -1730,6 +1809,10 @@ mod platform {
             0x81 => "f18",
             0x82 => "f19",
             0x83 => "f20",
+            0x84 => "f21",
+            0x85 => "f22",
+            0x86 => "f23",
+            WINDOWS_FN_VK => "fn",
             _ => return Some(format!("vk:{vk}")),
         };
 

--- a/tauri-app/src-tauri/src/hotkey.rs
+++ b/tauri-app/src-tauri/src/hotkey.rs
@@ -1154,26 +1154,17 @@ mod platform {
     const MOD_CONTROL: u64 = 1 << 1;
     const MOD_OPTION: u64 = 1 << 2;
     const MOD_SHIFT: u64 = 1 << 3;
-    const WINDOWS_FN_VK: u16 = 0x14; // CapsLock is the Windows stand-in for fn.
-
     /// Install a low-level keyboard hook (WH_KEYBOARD_LL).
     pub fn start(spec: HotkeySpec) {
         if RUNNING.swap(true, Ordering::SeqCst) {
             return;
         }
 
-        let mut target_vks = spec
+        let target_vks = spec
             .triggers
             .iter()
             .filter_map(|trigger| vk_for_trigger(trigger))
             .collect::<Vec<_>>();
-
-        // Windows does not expose most hardware Fn keys to user-space hooks.
-        // Preserve the previous app behavior by treating configured `fn` as
-        // CapsLock in the Windows backend, including for fn+key chains.
-        if spec.modifiers.contains(&HotkeyModifier::Fn) && !target_vks.contains(&WINDOWS_FN_VK) {
-            target_vks.insert(0, WINDOWS_FN_VK);
-        }
 
         if let Ok(mut targets) = TARGET_VKS.lock() {
             *targets = target_vks;
@@ -1591,7 +1582,7 @@ mod platform {
             "escape" => 0x1B,
             "delete" => 0x08,
             "forwarddelete" => 0x2E,
-            "fn" | "capslock" => WINDOWS_FN_VK,
+            "capslock" => 0x14,
             "left" => 0x25,
             "up" => 0x26,
             "right" => 0x27,
@@ -1699,7 +1690,7 @@ mod platform {
             0x1B => "escape",
             0x08 => "delete",
             0x2E => "forwarddelete",
-            WINDOWS_FN_VK => "fn",
+            0x14 => "capslock",
             0x25 => "left",
             0x26 => "up",
             0x27 => "right",

--- a/tauri-app/src-tauri/src/hotkey.rs
+++ b/tauri-app/src-tauri/src/hotkey.rs
@@ -1154,7 +1154,7 @@ mod platform {
     const MOD_CONTROL: u64 = 1 << 1;
     const MOD_OPTION: u64 = 1 << 2;
     const MOD_SHIFT: u64 = 1 << 3;
-    const MOD_FN: u64 = 1 << 4;
+    const WINDOWS_FN_VK: u16 = 0x14; // CapsLock is the Windows stand-in for fn.
 
     /// Install a low-level keyboard hook (WH_KEYBOARD_LL).
     pub fn start(spec: HotkeySpec) {
@@ -1162,12 +1162,21 @@ mod platform {
             return;
         }
 
+        let mut target_vks = spec
+            .triggers
+            .iter()
+            .filter_map(|trigger| vk_for_trigger(trigger))
+            .collect::<Vec<_>>();
+
+        // Windows does not expose most hardware Fn keys to user-space hooks.
+        // Preserve the previous app behavior by treating configured `fn` as
+        // CapsLock in the Windows backend, including for fn+key chains.
+        if spec.modifiers.contains(&HotkeyModifier::Fn) && !target_vks.contains(&WINDOWS_FN_VK) {
+            target_vks.insert(0, WINDOWS_FN_VK);
+        }
+
         if let Ok(mut targets) = TARGET_VKS.lock() {
-            *targets = spec
-                .triggers
-                .iter()
-                .filter_map(|trigger| vk_for_trigger(trigger))
-                .collect();
+            *targets = target_vks;
         }
         if let Ok(mut pressed) = PRESSED_TARGET_VKS.lock() {
             pressed.clear();
@@ -1378,9 +1387,6 @@ mod platform {
         if (modifiers & MOD_SHIFT) != 0 {
             parts.push("shift");
         }
-        if (modifiers & MOD_FN) != 0 {
-            parts.push("fn");
-        }
         for trigger in triggers {
             parts.push(trigger);
         }
@@ -1522,7 +1528,7 @@ mod platform {
                 HotkeyModifier::Control => MOD_CONTROL,
                 HotkeyModifier::Option => MOD_OPTION,
                 HotkeyModifier::Shift => MOD_SHIFT,
-                HotkeyModifier::Fn => MOD_FN,
+                HotkeyModifier::Fn => 0,
             }
         })
     }
@@ -1533,7 +1539,6 @@ mod platform {
             0x11 | 0xA2 | 0xA3 => Some(MOD_CONTROL),
             0x12 | 0xA4 | 0xA5 => Some(MOD_OPTION),
             0x10 | 0xA0 | 0xA1 => Some(MOD_SHIFT),
-            0x14 => Some(MOD_FN), // CapsLock as fn equivalent on Windows
             _ => None,
         }
     }
@@ -1586,7 +1591,7 @@ mod platform {
             "escape" => 0x1B,
             "delete" => 0x08,
             "forwarddelete" => 0x2E,
-            "capslock" => 0x14,
+            "fn" | "capslock" => WINDOWS_FN_VK,
             "left" => 0x25,
             "up" => 0x26,
             "right" => 0x27,
@@ -1694,7 +1699,7 @@ mod platform {
             0x1B => "escape",
             0x08 => "delete",
             0x2E => "forwarddelete",
-            0x14 => "capslock",
+            WINDOWS_FN_VK => "fn",
             0x25 => "left",
             0x26 => "up",
             0x27 => "right",

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -11,10 +11,11 @@ mod transcription;
 mod tray;
 #[cfg(target_os = "windows")]
 mod win_overlay;
+mod windows;
 
 use std::sync::Arc;
 
-use tauri::{Listener, Manager};
+use tauri::{Emitter, Listener, Manager};
 
 use crate::config::AppConfig;
 use crate::history::HistoryEntry;
@@ -83,12 +84,7 @@ async fn transcribe(audio_path: String) -> Result<String, String> {
         el_language_code: cfg.el_language_code.clone(),
     };
 
-    transcription::transcribe(
-        cfg.tx_provider,
-        std::path::Path::new(&audio_path),
-        &options,
-    )
-    .await
+    transcription::transcribe(cfg.tx_provider, std::path::Path::new(&audio_path), &options).await
 }
 
 /// Format raw transcription text with the configured LLM.
@@ -132,7 +128,12 @@ fn add_history_entry(
     formatting_provider: Option<String>,
     formatting_style: Option<String>,
 ) -> Result<HistoryEntry, String> {
-    history::append(text, transcription_provider, formatting_provider, formatting_style)
+    history::append(
+        text,
+        transcription_provider,
+        formatting_provider,
+        formatting_style,
+    )
 }
 
 /// Remove a history entry by ID.
@@ -184,11 +185,31 @@ fn get_pipeline_state(orch: tauri::State<'_, Arc<Orchestrator>>) -> orchestrator
 /// Show the settings window. Used by the fallback root route.
 #[tauri::command]
 fn show_settings(app: tauri::AppHandle) -> Result<(), String> {
-    if let Some(window) = app.get_webview_window("settings") {
-        window.show().map_err(|e| e.to_string())?;
-        window.set_focus().map_err(|e| e.to_string())?;
-    }
-    Ok(())
+    windows::show_app_window(&app, "settings")
+}
+
+/// Hide an app window without destroying it so it can be reopened from the tray.
+#[tauri::command]
+fn hide_app_window(app: tauri::AppHandle, label: String) -> Result<(), String> {
+    windows::hide_app_window(&app, &label)
+}
+
+#[tauri::command]
+fn start_hotkey_capture(app: tauri::AppHandle) {
+    let preview_app = app.clone();
+    hotkey::begin_capture(
+        move |shortcut| {
+            let _ = preview_app.emit_to("settings", "settings:hotkey-preview", shortcut);
+        },
+        move |shortcut| {
+            let _ = app.emit_to("settings", "settings:hotkey-captured", shortcut);
+        },
+    );
+}
+
+#[tauri::command]
+fn cancel_hotkey_capture() {
+    hotkey::cancel_capture();
 }
 
 // ---------------------------------------------------------------------------
@@ -203,12 +224,14 @@ pub fn run() {
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             None,
         ))
+        .on_window_event(windows::handle_window_event)
         .setup(|app| {
             // Initialize the orchestrator -- this loads config, starts
             // the hotkey listener, sets up the tray, and begins the
             // audio level poller.
             let handle = app.handle().clone();
             orchestrator::init(&handle);
+            windows::hide_app_if_no_windows_visible(&handle);
 
             // Listen for tray toggle-enabled event
             let handle2 = app.handle().clone();
@@ -245,6 +268,9 @@ pub fn run() {
             toggle_enabled,
             get_pipeline_state,
             show_settings,
+            hide_app_window,
+            start_hotkey_capture,
+            cancel_hotkey_capture,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri-app/src-tauri/src/orchestrator.rs
+++ b/tauri-app/src-tauri/src/orchestrator.rs
@@ -192,6 +192,8 @@ struct OrchestratorInner {
     peak_level: f32,
     /// Timestamp when the current recording started.
     recording_start: Option<Instant>,
+    /// Elapsed recording time banked before the current pause/resume segment.
+    recording_elapsed_before_pause: Duration,
     /// Monotonic id for the active/most recent recording attempt. Used to
     /// cancel delayed feedback from a tap that became part of a double-tap.
     recording_generation: u64,
@@ -220,7 +222,7 @@ struct OrchestratorInner {
 impl OrchestratorInner {
     fn begin_press_pending(&mut self) -> u64 {
         self.state = AppState::PressPending;
-        self.recording_start = Some(Instant::now());
+        self.reset_recording_clock();
         self.peak_level = 0.0;
         self.recording_generation = self.recording_generation.wrapping_add(1);
         let generation = self.recording_generation;
@@ -230,7 +232,7 @@ impl OrchestratorInner {
 
     fn begin_recording(&mut self) -> u64 {
         self.state = AppState::Recording;
-        self.recording_start = Some(Instant::now());
+        self.reset_recording_clock();
         self.peak_level = 0.0;
         self.recording_generation = self.recording_generation.wrapping_add(1);
         let generation = self.recording_generation;
@@ -243,10 +245,33 @@ impl OrchestratorInner {
             return false;
         }
         self.state = AppState::Recording;
-        self.recording_start = Some(Instant::now());
+        self.reset_recording_clock();
         self.peak_level = 0.0;
         self.emit_state();
         true
+    }
+
+    fn reset_recording_clock(&mut self) {
+        self.recording_start = Some(Instant::now());
+        self.recording_elapsed_before_pause = Duration::ZERO;
+    }
+
+    fn pause_recording_clock(&mut self) {
+        if let Some(start) = self.recording_start.take() {
+            self.recording_elapsed_before_pause += start.elapsed();
+        }
+    }
+
+    fn resume_recording_clock(&mut self) {
+        self.recording_start = Some(Instant::now());
+    }
+
+    fn recording_elapsed(&self) -> Duration {
+        self.recording_elapsed_before_pause
+            + self
+                .recording_start
+                .map(|start| start.elapsed())
+                .unwrap_or_default()
     }
 
     /// Emit an overlay display state to every renderer without changing the
@@ -307,41 +332,21 @@ impl OrchestratorInner {
 
         // Include hands-free metadata when in a recording state
         let (hands_free, paused, elapsed) = match self.state {
-            AppState::HandsFreeRecording => {
-                let elapsed = self
-                    .recording_start
-                    .map(|s| s.elapsed().as_secs_f64())
-                    .unwrap_or(0.0);
-                (Some(true), Some(false), Some(elapsed))
-            }
-            AppState::HandsFreePaused => {
-                let elapsed = self
-                    .recording_start
-                    .map(|s| s.elapsed().as_secs_f64())
-                    .unwrap_or(0.0);
-                (Some(true), Some(true), Some(elapsed))
-            }
-            AppState::Recording => {
-                let elapsed = self
-                    .recording_start
-                    .map(|s| s.elapsed().as_secs_f64())
-                    .unwrap_or(0.0);
-                (Some(false), None, Some(elapsed))
-            }
-            AppState::PressPending => {
-                let elapsed = self
-                    .recording_start
-                    .map(|s| s.elapsed().as_secs_f64())
-                    .unwrap_or(0.0);
-                (Some(false), None, Some(elapsed))
-            }
-            AppState::TapPending => {
-                let elapsed = self
-                    .recording_start
-                    .map(|s| s.elapsed().as_secs_f64())
-                    .unwrap_or(0.0);
-                (Some(false), None, Some(elapsed))
-            }
+            AppState::HandsFreeRecording => (
+                Some(true),
+                Some(false),
+                Some(self.recording_elapsed().as_secs_f64()),
+            ),
+            AppState::HandsFreePaused => (
+                Some(true),
+                Some(true),
+                Some(self.recording_elapsed().as_secs_f64()),
+            ),
+            AppState::Recording | AppState::PressPending | AppState::TapPending => (
+                Some(false),
+                None,
+                Some(self.recording_elapsed().as_secs_f64()),
+            ),
             _ => (None, None, None),
         };
 
@@ -459,6 +464,7 @@ impl Orchestrator {
                 enabled: true,
                 peak_level: 0.0,
                 recording_start: None,
+                recording_elapsed_before_pause: Duration::ZERO,
                 recording_generation: 0,
                 ignore_pending_key_up: false,
                 app,
@@ -659,10 +665,7 @@ impl Orchestrator {
             return;
         }
 
-        let duration = inner
-            .recording_start
-            .map(|s| s.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let duration = inner.recording_elapsed().as_secs_f64();
         let peak = inner.peak_level;
         drop(inner);
 
@@ -768,12 +771,14 @@ impl Orchestrator {
         match inner.state {
             AppState::HandsFreeRecording => {
                 audio::pause_recording();
+                inner.pause_recording_clock();
                 inner.state = AppState::HandsFreePaused;
                 inner.emit_state();
                 log::info("Hands-free: paused");
             }
             AppState::HandsFreePaused => {
                 audio::resume_recording();
+                inner.resume_recording_clock();
                 inner.state = AppState::HandsFreeRecording;
                 inner.emit_state();
                 log::info("Hands-free: resumed");

--- a/tauri-app/src-tauri/src/orchestrator.rs
+++ b/tauri-app/src-tauri/src/orchestrator.rs
@@ -18,10 +18,11 @@ use crate::audio::{self, AudioLevels};
 use crate::config::{self, AppConfig};
 use crate::formatting::{self, FormattingOptions, FormattingProvider};
 use crate::history;
-use crate::hotkey::{self, HotkeyModifier};
+use crate::hotkey::{self, HotkeySpec};
 use crate::paste;
 use crate::transcription::{self, TranscriptionOptions, TranscriptionProvider};
 use crate::tray;
+use crate::windows;
 
 const SHORT_TAP_TIP_GRACE: Duration =
     Duration::from_millis((hotkey::DOUBLE_TAP_WINDOW * 1000.0) as u64 + 100);
@@ -153,7 +154,10 @@ fn onboarding_text(step: &OnboardingStep, hotkey_label: &str) -> String {
         ),
         OnboardingStep::Nice => {
             let mut rng = rand::rng();
-            NICE_MESSAGES.choose(&mut rng).unwrap_or(&"Nice! \u{1f389}").to_string()
+            NICE_MESSAGES
+                .choose(&mut rng)
+                .unwrap_or(&"Nice! \u{1f389}")
+                .to_string()
         }
         OnboardingStep::DoubleTapTip => format!(
             "Double-tap <span class=\"keycap\">{}</span> for hands-free transcription",
@@ -198,7 +202,6 @@ struct OrchestratorInner {
     app: AppHandle,
 
     // -- Onboarding state --
-
     /// Current onboarding step (None = onboarding complete or not started).
     onboarding_step: Option<OnboardingStep>,
     /// Whether onboarding is complete (mirrors config.onboarding_complete).
@@ -256,12 +259,15 @@ impl OrchestratorInner {
         paused: Option<bool>,
         elapsed: Option<f64>,
     ) {
-        let _ = self.app.emit("state:change", StateChangePayload {
-            state: state_str.to_string(),
-            hands_free,
-            paused,
-            elapsed,
-        });
+        let _ = self.app.emit(
+            "state:change",
+            StateChangePayload {
+                state: state_str.to_string(),
+                hands_free,
+                paused,
+                elapsed,
+            },
+        );
 
         #[cfg(target_os = "macos")]
         crate::sidecar::send(&crate::sidecar::OutMessage::State {
@@ -302,31 +308,36 @@ impl OrchestratorInner {
         // Include hands-free metadata when in a recording state
         let (hands_free, paused, elapsed) = match self.state {
             AppState::HandsFreeRecording => {
-                let elapsed = self.recording_start
+                let elapsed = self
+                    .recording_start
                     .map(|s| s.elapsed().as_secs_f64())
                     .unwrap_or(0.0);
                 (Some(true), Some(false), Some(elapsed))
             }
             AppState::HandsFreePaused => {
-                let elapsed = self.recording_start
+                let elapsed = self
+                    .recording_start
                     .map(|s| s.elapsed().as_secs_f64())
                     .unwrap_or(0.0);
                 (Some(true), Some(true), Some(elapsed))
             }
             AppState::Recording => {
-                let elapsed = self.recording_start
+                let elapsed = self
+                    .recording_start
                     .map(|s| s.elapsed().as_secs_f64())
                     .unwrap_or(0.0);
                 (Some(false), None, Some(elapsed))
             }
             AppState::PressPending => {
-                let elapsed = self.recording_start
+                let elapsed = self
+                    .recording_start
                     .map(|s| s.elapsed().as_secs_f64())
                     .unwrap_or(0.0);
                 (Some(false), None, Some(elapsed))
             }
             AppState::TapPending => {
-                let elapsed = self.recording_start
+                let elapsed = self
+                    .recording_start
                     .map(|s| s.elapsed().as_secs_f64())
                     .unwrap_or(0.0);
                 (Some(false), None, Some(elapsed))
@@ -340,7 +351,12 @@ impl OrchestratorInner {
 
     /// Emit an error event to the frontend.
     fn emit_error(&self, message: &str) {
-        let _ = self.app.emit("error:show", ErrorPayload { message: message.to_string() });
+        let _ = self.app.emit(
+            "error:show",
+            ErrorPayload {
+                message: message.to_string(),
+            },
+        );
         #[cfg(target_os = "macos")]
         crate::sidecar::send(&crate::sidecar::OutMessage::Error {
             message: message.to_string(),
@@ -376,16 +392,25 @@ impl OrchestratorInner {
 
     /// Emit onboarding step change to the frontend.
     fn emit_onboarding(&self) {
-        let step_str = self.onboarding_step.as_ref().map(|s| s.to_str().to_string()).unwrap_or_default();
-        let text = self.onboarding_step.as_ref()
+        let step_str = self
+            .onboarding_step
+            .as_ref()
+            .map(|s| s.to_str().to_string())
+            .unwrap_or_default();
+        let text = self
+            .onboarding_step
+            .as_ref()
             .map(|s| onboarding_text(s, &self.hotkey_label))
             .unwrap_or_default();
 
-        let _ = self.app.emit("onboarding:step", OnboardingPayload {
-            step: step_str.clone(),
-            text: text.clone(),
-            hotkey_label: self.hotkey_label.clone(),
-        });
+        let _ = self.app.emit(
+            "onboarding:step",
+            OnboardingPayload {
+                step: step_str.clone(),
+                text: text.clone(),
+                hotkey_label: self.hotkey_label.clone(),
+            },
+        );
 
         #[cfg(target_os = "macos")]
         crate::sidecar::send(&crate::sidecar::OutMessage::Onboarding {
@@ -427,11 +452,7 @@ pub struct Orchestrator {
 impl Orchestrator {
     /// Create a new orchestrator and bind it to the given `AppHandle`.
     fn new(app: AppHandle, cfg: &AppConfig) -> Self {
-        let hotkey_label = if cfg.hotkey == "option" {
-            "option".to_string()
-        } else {
-            "fn".to_string()
-        };
+        let hotkey_label = hotkey_display_label(&cfg.hotkey);
         Self {
             inner: Mutex::new(OrchestratorInner {
                 state: AppState::Idle,
@@ -509,13 +530,17 @@ impl Orchestrator {
                     return;
                 }
                 // Confirmation steps: fn hold advances onboarding, never records
-                OnboardingStep::ApiTip | OnboardingStep::FormattingTip | OnboardingStep::Welcome => {
+                OnboardingStep::ApiTip
+                | OnboardingStep::FormattingTip
+                | OnboardingStep::Welcome => {
                     log::info(&format!("Hold-to-confirm for: {:?}", eff_step));
                     inner.hold_confirm_start = Some(Instant::now());
                     // Emit a "pressed" event so the frontend can show scale-down feedback
                     let _ = inner.app.emit("onboarding:press", true);
                     #[cfg(target_os = "macos")]
-                    crate::sidecar::send(&crate::sidecar::OutMessage::OnboardingPress { pressed: true });
+                    crate::sidecar::send(&crate::sidecar::OutMessage::OnboardingPress {
+                        pressed: true,
+                    });
                     #[cfg(target_os = "windows")]
                     crate::win_overlay::update_state(|st| st.is_pressed = true);
                     let app = inner.app.clone();
@@ -856,21 +881,17 @@ impl Orchestrator {
         log::info("Settings changed -- reloading");
         let cfg = config::get();
 
-        // Restart hotkey with new modifier
+        // Restart hotkey with the configured shortcut.
         hotkey::stop();
-        let modifier = parse_hotkey_modifier(&cfg.hotkey);
+        let spec = parse_hotkey_spec(&cfg.hotkey);
         let app = self.app_handle();
         let orch = app.state::<Arc<Orchestrator>>();
-        start_hotkey_listener(Arc::clone(&orch), modifier);
+        start_hotkey_listener(Arc::clone(&orch), spec);
 
         // Update hotkey label for onboarding cards
         {
             let mut inner = self.inner.lock().unwrap();
-            inner.hotkey_label = if cfg.hotkey == "option" {
-                "option".to_string()
-            } else {
-                "fn".to_string()
-            };
+            inner.hotkey_label = hotkey_display_label(&cfg.hotkey);
             // Re-emit onboarding if active (to update keycap labels)
             if inner.onboarding_step.is_some() {
                 inner.emit_onboarding();
@@ -880,12 +901,18 @@ impl Orchestrator {
         // Push appearance settings to the overlay
         {
             let inner = self.inner.lock().unwrap();
-            let _ = inner.app.emit("gradient:toggle", serde_json::json!({
-                "enabled": cfg.gradient_enabled,
-            }));
-            let _ = inner.app.emit("overlay:visibility", serde_json::json!({
-                "visible": cfg.always_visible_pill,
-            }));
+            let _ = inner.app.emit(
+                "gradient:toggle",
+                serde_json::json!({
+                    "enabled": cfg.gradient_enabled,
+                }),
+            );
+            let _ = inner.app.emit(
+                "overlay:visibility",
+                serde_json::json!({
+                    "visible": cfg.always_visible_pill,
+                }),
+            );
             let _ = inner.app.emit("settings:changed", ());
 
             #[cfg(target_os = "macos")]
@@ -1176,10 +1203,7 @@ impl Orchestrator {
             inner.emit_error("Set up an API key in Settings");
             drop(inner);
             // Auto-open settings window
-            if let Some(win) = app.get_webview_window("settings") {
-                let _ = win.show();
-                let _ = win.set_focus();
-            }
+            let _ = windows::show_app_window(&app, "settings");
             return;
         }
 
@@ -1219,12 +1243,7 @@ impl Orchestrator {
                         } else {
                             None
                         };
-                        let _ = history::append(
-                            text.clone(),
-                            tx_provider,
-                            fmt_provider,
-                            fmt_style,
-                        );
+                        let _ = history::append(text.clone(), tx_provider, fmt_provider, fmt_style);
 
                         // Refresh tray history menu
                         let app = orch.app_handle();
@@ -1450,18 +1469,19 @@ pub(crate) fn play_sound(app: &AppHandle, name: &str) {
 // Hotkey modifier parsing
 // ---------------------------------------------------------------------------
 
-fn parse_hotkey_modifier(hotkey: &str) -> HotkeyModifier {
-    match hotkey {
-        "option" => HotkeyModifier::Option,
-        _ => HotkeyModifier::Fn,
-    }
+fn parse_hotkey_spec(hotkey: &str) -> HotkeySpec {
+    HotkeySpec::parse(hotkey)
+}
+
+fn hotkey_display_label(hotkey: &str) -> String {
+    parse_hotkey_spec(hotkey).label()
 }
 
 // ---------------------------------------------------------------------------
 // Hotkey listener setup (connects hotkey callbacks to orchestrator)
 // ---------------------------------------------------------------------------
 
-fn start_hotkey_listener(orch: Arc<Orchestrator>, modifier: HotkeyModifier) {
+fn start_hotkey_listener(orch: Arc<Orchestrator>, spec: HotkeySpec) {
     let orch_down = Arc::clone(&orch);
     let orch_up = Arc::clone(&orch);
     let orch_double = Arc::clone(&orch);
@@ -1472,7 +1492,7 @@ fn start_hotkey_listener(orch: Arc<Orchestrator>, modifier: HotkeyModifier) {
         move || orch_double.on_double_tap(),
     );
 
-    hotkey::start(modifier);
+    hotkey::start(spec);
 }
 
 // ---------------------------------------------------------------------------
@@ -1534,9 +1554,9 @@ pub fn init(app: &AppHandle) {
     let _ = tray::setup_tray(app);
 
     // Start hotkey listener
-    let modifier = parse_hotkey_modifier(&cfg.hotkey);
-    log::info(&format!("Starting hotkey: {:?}", modifier));
-    start_hotkey_listener(Arc::clone(&orch), modifier);
+    let spec = parse_hotkey_spec(&cfg.hotkey);
+    log::info(&format!("Starting hotkey: {}", spec.label()));
+    start_hotkey_listener(Arc::clone(&orch), spec);
 
     // Start audio level poller
     start_level_poller(Arc::clone(&orch));

--- a/tauri-app/src-tauri/src/paste.rs
+++ b/tauri-app/src-tauri/src/paste.rs
@@ -32,9 +32,7 @@ pub fn paste_text(text: &str) -> Result<(), String> {
 
     // --- Step 6: Restore previous clipboard ---
     match previous {
-        Some(prev) => clipboard
-            .set_text(prev)
-            .map_err(|e| e.to_string())?,
+        Some(prev) => clipboard.set_text(prev).map_err(|e| e.to_string())?,
         None => clipboard.clear().map_err(|e| e.to_string())?,
     }
 

--- a/tauri-app/src-tauri/src/sidecar.rs
+++ b/tauri-app/src-tauri/src/sidecar.rs
@@ -105,8 +105,13 @@ pub fn spawn(app: &tauri::AppHandle) {
     let bin = if dev_path.exists() {
         dev_path
     } else if let Some(ref bp) = bundled_path {
-        if bp.exists() { bp.clone() } else {
-            orchestrator::log::info(&format!("Sidecar binary not found at {:?} or {:?}", dev_path, bundled_path));
+        if bp.exists() {
+            bp.clone()
+        } else {
+            orchestrator::log::info(&format!(
+                "Sidecar binary not found at {:?} or {:?}",
+                dev_path, bundled_path
+            ));
             return;
         }
     } else {
@@ -148,7 +153,9 @@ pub fn spawn(app: &tauri::AppHandle) {
                     Ok(l) => l,
                     Err(_) => break,
                 };
-                if line.is_empty() { continue; }
+                if line.is_empty() {
+                    continue;
+                }
 
                 let parsed: serde_json::Value = match serde_json::from_str(&line) {
                     Ok(v) => v,

--- a/tauri-app/src-tauri/src/speech.rs
+++ b/tauri-app/src-tauri/src/speech.rs
@@ -34,8 +34,7 @@ mod platform {
         let path_str = audio_path
             .to_str()
             .ok_or_else(|| "invalid audio path".to_string())?;
-        let path_cstr =
-            CString::new(path_str).map_err(|e| format!("path encoding error: {e}"))?;
+        let path_cstr = CString::new(path_str).map_err(|e| format!("path encoding error: {e}"))?;
         let locale_cstr =
             CString::new(locale).map_err(|e| format!("locale encoding error: {e}"))?;
 
@@ -43,8 +42,8 @@ mod platform {
 
         unsafe {
             // -- Create autorelease pool --
-            let pool_cls = AnyClass::get(c"NSAutoreleasePool")
-                .ok_or("NSAutoreleasePool not found")?;
+            let pool_cls =
+                AnyClass::get(c"NSAutoreleasePool").ok_or("NSAutoreleasePool not found")?;
             let pool: *mut AnyObject = msg_send![pool_cls, new];
 
             // -- Create NSString helpers --
@@ -92,48 +91,41 @@ mod platform {
             // -- Build the result handler block --
             // Called by the Speech framework with partial/final results.
             // We only care about the final result (isFinal == true).
-            let block = RcBlock::new(
-                move |result: *mut AnyObject, error: *mut AnyObject| {
-                    // Error with no result → terminal failure
-                    if !error.is_null() && result.is_null() {
-                        let desc: *mut AnyObject = msg_send![error, localizedDescription];
-                        if !desc.is_null() {
-                            let cstr: *const c_char = msg_send![desc, UTF8String];
-                            if !cstr.is_null() {
-                                let err_str =
-                                    CStr::from_ptr(cstr).to_string_lossy().to_string();
-                                let _ = tx.send(Err(err_str));
-                                return;
-                            }
+            let block = RcBlock::new(move |result: *mut AnyObject, error: *mut AnyObject| {
+                // Error with no result → terminal failure
+                if !error.is_null() && result.is_null() {
+                    let desc: *mut AnyObject = msg_send![error, localizedDescription];
+                    if !desc.is_null() {
+                        let cstr: *const c_char = msg_send![desc, UTF8String];
+                        if !cstr.is_null() {
+                            let err_str = CStr::from_ptr(cstr).to_string_lossy().to_string();
+                            let _ = tx.send(Err(err_str));
+                            return;
                         }
-                        let _ = tx.send(Err("Speech recognition error".to_string()));
-                        return;
                     }
+                    let _ = tx.send(Err("Speech recognition error".to_string()));
+                    return;
+                }
 
-                    if !result.is_null() {
-                        let is_final: bool = msg_send![result, isFinal];
-                        if is_final {
-                            let transcription: *mut AnyObject =
-                                msg_send![result, bestTranscription];
-                            if !transcription.is_null() {
-                                let text: *mut AnyObject =
-                                    msg_send![transcription, formattedString];
-                                if !text.is_null() {
-                                    let cstr: *const c_char = msg_send![text, UTF8String];
-                                    if !cstr.is_null() {
-                                        let s = CStr::from_ptr(cstr)
-                                            .to_string_lossy()
-                                            .to_string();
-                                        let _ = tx.send(Ok(s));
-                                        return;
-                                    }
+                if !result.is_null() {
+                    let is_final: bool = msg_send![result, isFinal];
+                    if is_final {
+                        let transcription: *mut AnyObject = msg_send![result, bestTranscription];
+                        if !transcription.is_null() {
+                            let text: *mut AnyObject = msg_send![transcription, formattedString];
+                            if !text.is_null() {
+                                let cstr: *const c_char = msg_send![text, UTF8String];
+                                if !cstr.is_null() {
+                                    let s = CStr::from_ptr(cstr).to_string_lossy().to_string();
+                                    let _ = tx.send(Ok(s));
+                                    return;
                                 }
                             }
-                            let _ = tx.send(Ok(String::new()));
                         }
+                        let _ = tx.send(Ok(String::new()));
                     }
-                },
-            );
+                }
+            });
 
             // -- Start recognition task --
             let _task: *mut AnyObject = msg_send![
@@ -149,9 +141,7 @@ mod platform {
         // Wait for the final result with a 10-second timeout
         match rx.recv_timeout(Duration::from_secs(10)) {
             Ok(result) => result,
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                Err("Speech recognition timed out".to_string())
-            }
+            Err(mpsc::RecvTimeoutError::Timeout) => Err("Speech recognition timed out".to_string()),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 Err("Speech recognition channel closed unexpectedly".to_string())
             }

--- a/tauri-app/src-tauri/src/transcription.rs
+++ b/tauri-app/src-tauri/src/transcription.rs
@@ -173,7 +173,12 @@ async fn transcribe_gemini(
             .json(&body)
             .send()
             .await
-            .map_err(|e| (format!("Gemini request failed: {e}"), is_retryable_error(&e)))?;
+            .map_err(|e| {
+                (
+                    format!("Gemini request failed: {e}"),
+                    is_retryable_error(&e),
+                )
+            })?;
 
         let status = resp.status();
         let text = resp
@@ -255,7 +260,12 @@ async fn transcribe_openai(
                 .multipart(form)
                 .send()
                 .await
-                .map_err(|e| (format!("OpenAI request failed: {e}"), is_retryable_error(&e)))?;
+                .map_err(|e| {
+                    (
+                        format!("OpenAI request failed: {e}"),
+                        is_retryable_error(&e),
+                    )
+                })?;
 
             let status = resp.status();
             let text = resp
@@ -315,17 +325,10 @@ async fn transcribe_deepgram(
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
     {
-        params.push(format!(
-            "{}={}",
-            boost_param,
-            urlencoding_simple(kw)
-        ));
+        params.push(format!("{}={}", boost_param, urlencoding_simple(kw)));
     }
 
-    let url = format!(
-        "https://api.deepgram.com/v1/listen?{}",
-        params.join("&")
-    );
+    let url = format!("https://api.deepgram.com/v1/listen?{}", params.join("&"));
 
     with_retry(MAX_RETRIES, || {
         let audio_data = audio_data.clone();
@@ -342,7 +345,12 @@ async fn transcribe_deepgram(
                 .body(audio_data)
                 .send()
                 .await
-                .map_err(|e| (format!("Deepgram request failed: {e}"), is_retryable_error(&e)))?;
+                .map_err(|e| {
+                    (
+                        format!("Deepgram request failed: {e}"),
+                        is_retryable_error(&e),
+                    )
+                })?;
 
             let status = resp.status();
             let text = resp

--- a/tauri-app/src-tauri/src/tray.rs
+++ b/tauri-app/src-tauri/src/tray.rs
@@ -2,10 +2,11 @@ use tauri::{
     image::Image,
     menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
     tray::TrayIconBuilder,
-    AppHandle, Emitter, Manager,
+    AppHandle, Emitter,
 };
 
 use crate::history;
+use crate::windows;
 
 /// Build and attach the system tray icon with its menu.
 ///
@@ -14,7 +15,7 @@ use crate::history;
 ///   ----
 ///   Enabled          (check item)
 ///   History >        (submenu with recent entries)
-///   Settings...
+///   Open Yap...
 ///   ----
 ///   Quit
 pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
@@ -33,7 +34,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
     // History submenu
     let history_submenu = build_history_submenu(app)?;
 
-    let settings_item = MenuItemBuilder::with_id("settings", "Settings...")
+    let settings_item = MenuItemBuilder::with_id("settings", "Open Yap...")
         .build(app)
         .map_err(|e| format!("failed to create settings item: {e}"))?;
 
@@ -72,16 +73,10 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
                     let _ = app.emit("tray:toggle-enabled", ());
                 }
                 "settings" => {
-                    if let Some(window) = app.get_webview_window("settings") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    }
+                    let _ = windows::show_app_window(app, "settings");
                 }
                 "show_history" => {
-                    if let Some(window) = app.get_webview_window("history") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    }
+                    let _ = windows::show_app_window(app, "history");
                     let _ = app.emit("tray:show-history", ());
                 }
                 "clear_history" => {
@@ -113,9 +108,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
 }
 
 /// Build the history submenu from current entries.
-fn build_history_submenu(
-    app: &AppHandle,
-) -> Result<tauri::menu::Submenu<tauri::Wry>, String> {
+fn build_history_submenu(app: &AppHandle) -> Result<tauri::menu::Submenu<tauri::Wry>, String> {
     let entries = history::load();
 
     let mut builder = SubmenuBuilder::with_id(app, "history", "History");
@@ -193,8 +186,7 @@ pub fn refresh_history_menu(app: &AppHandle) {
             let enabled_item = CheckMenuItemBuilder::with_id("toggle_enabled", "Enabled")
                 .checked(true)
                 .build(app);
-            let settings_item = MenuItemBuilder::with_id("settings", "Settings...")
-                .build(app);
+            let settings_item = MenuItemBuilder::with_id("settings", "Open Yap...").build(app);
             let quit_item = MenuItemBuilder::with_id("quit", "Quit").build(app);
 
             if let (Ok(title), Ok(enabled), Ok(settings), Ok(quit)) =

--- a/tauri-app/src-tauri/src/windows.rs
+++ b/tauri-app/src-tauri/src/windows.rs
@@ -1,0 +1,69 @@
+use tauri::{AppHandle, Manager, WebviewWindow, Window, WindowEvent};
+
+const APP_WINDOW_LABELS: &[&str] = &["settings", "history"];
+
+pub fn show_app_window(app: &AppHandle, label: &str) -> Result<(), String> {
+    let window = app
+        .get_webview_window(label)
+        .ok_or_else(|| format!("window not found: {label}"))?;
+
+    activate_app(app);
+    window.unminimize().map_err(|e| e.to_string())?;
+    window.show().map_err(|e| e.to_string())?;
+    window.set_focus().map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+pub fn hide_app_window(app: &AppHandle, label: &str) -> Result<(), String> {
+    let window = app
+        .get_webview_window(label)
+        .ok_or_else(|| format!("window not found: {label}"))?;
+
+    window.hide().map_err(|e| e.to_string())?;
+    hide_app_if_no_windows_visible(app);
+
+    Ok(())
+}
+
+pub fn handle_window_event(window: &Window, event: &WindowEvent) {
+    if !APP_WINDOW_LABELS.contains(&window.label()) {
+        return;
+    }
+
+    if let WindowEvent::CloseRequested { api, .. } = event {
+        api.prevent_close();
+        let _ = hide_app_window(window.app_handle(), window.label());
+    }
+}
+
+pub fn hide_app_if_no_windows_visible(app: &AppHandle) {
+    if app_windows(app).any(|window| window.is_visible().unwrap_or(false)) {
+        return;
+    }
+
+    deactivate_app(app);
+}
+
+fn app_windows(app: &AppHandle) -> impl Iterator<Item = WebviewWindow> + '_ {
+    APP_WINDOW_LABELS
+        .iter()
+        .filter_map(|label| app.get_webview_window(label))
+}
+
+#[cfg(target_os = "macos")]
+fn activate_app(app: &AppHandle) {
+    let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+    let _ = app.show();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn activate_app(_app: &AppHandle) {}
+
+#[cfg(target_os = "macos")]
+fn deactivate_app(app: &AppHandle) {
+    let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn deactivate_app(_app: &AppHandle) {}

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       },
       {
         "label": "settings",
-        "title": "Yap Settings",
+        "title": "Yap",
         "url": "/settings.html",
         "width": 500,
         "height": 680,

--- a/tauri-app/src/lib/history/History.svelte
+++ b/tauri-app/src/lib/history/History.svelte
@@ -9,7 +9,6 @@
 
   import './history.css';
   import { invoke } from '@tauri-apps/api/core';
-  import { getCurrentWindow } from '@tauri-apps/api/window';
 
   // ── Types ─────────────────────────────────────────────────────────────
 
@@ -135,8 +134,8 @@
 
   // ── Close Window ──────────────────────────────────────────────────────
 
-  function closeWindow() {
-    getCurrentWindow().hide();
+  async function closeWindow() {
+    await invoke('hide_app_window', { label: 'history' });
   }
 
   // ── Keyboard ──────────────────────────────────────────────────────────

--- a/tauri-app/src/lib/settings/Settings.svelte
+++ b/tauri-app/src/lib/settings/Settings.svelte
@@ -92,6 +92,7 @@
   };
 
   const styleExampleInput = 'yeah i was thinking we could try that new place on friday if youre free';
+  const modifierOrder = ['cmd', 'ctrl', 'option', 'shift', 'fn'];
 
   // ── State ─────────────────────────────────────────────────────────────
 
@@ -102,6 +103,8 @@
   let hotkey = $state('fn');
   let capturingHotkey = $state(false);
   let hotkeyPreview = $state('');
+  let webPressedHotkeyParts: string[] = [];
+  let webLastHotkey = '';
   let microphones = $state<string[]>([]);
   let selectedMic = $state('');
 
@@ -268,6 +271,7 @@
 
   async function toggleHotkeyCapture() {
     hotkeyPreview = '';
+    resetWebHotkeyCapture();
     capturingHotkey = !capturingHotkey;
 
     if (capturingHotkey) {
@@ -280,6 +284,7 @@
   function setCapturedHotkey(value: string) {
     hotkey = value;
     hotkeyPreview = '';
+    resetWebHotkeyCapture();
     capturingHotkey = false;
     void invoke('cancel_hotkey_capture');
   }
@@ -291,11 +296,29 @@
       e.preventDefault();
       e.stopPropagation();
 
-      if (e.key === 'Escape' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+      if (
+        e.key === 'Escape'
+        && !e.metaKey
+        && !e.ctrlKey
+        && !e.altKey
+        && !e.shiftKey
+        && webPressedHotkeyParts.length === 0
+      ) {
         hotkeyPreview = '';
+        resetWebHotkeyCapture();
         capturingHotkey = false;
         void invoke('cancel_hotkey_capture');
         return;
+      }
+
+      const key = canonicalKeyFromEvent(e);
+      syncWebModifiers(e);
+      if (key) addWebHotkeyPart(key);
+
+      const preview = webHotkeyFromPressed();
+      if (preview) {
+        webLastHotkey = preview;
+        hotkeyPreview = preview;
       }
       return;
     }
@@ -311,6 +334,101 @@
     if (!capturingHotkey) return;
     e.preventDefault();
     e.stopPropagation();
+
+    const key = canonicalKeyFromEvent(e);
+    if (key) removeWebHotkeyPart(key);
+    syncWebModifiers(e);
+
+    if (webPressedHotkeyParts.length === 0 && webLastHotkey) {
+      setCapturedHotkey(webLastHotkey);
+    }
+  }
+
+  function resetWebHotkeyCapture() {
+    webPressedHotkeyParts = [];
+    webLastHotkey = '';
+  }
+
+  function addWebHotkeyPart(part: string) {
+    if (!webPressedHotkeyParts.includes(part)) {
+      webPressedHotkeyParts = [...webPressedHotkeyParts, part];
+    }
+  }
+
+  function removeWebHotkeyPart(part: string) {
+    webPressedHotkeyParts = webPressedHotkeyParts.filter((pressed) => pressed !== part);
+  }
+
+  function syncWebModifiers(e: KeyboardEvent) {
+    syncWebModifier('cmd', e.metaKey);
+    syncWebModifier('ctrl', e.ctrlKey);
+    syncWebModifier('option', e.altKey);
+    syncWebModifier('shift', e.shiftKey);
+  }
+
+  function syncWebModifier(part: string, pressed: boolean) {
+    if (pressed) {
+      addWebHotkeyPart(part);
+    } else {
+      removeWebHotkeyPart(part);
+    }
+  }
+
+  function webHotkeyFromPressed(): string {
+    const modifiers = modifierOrder.filter((modifier) => webPressedHotkeyParts.includes(modifier));
+    const triggers = webPressedHotkeyParts.filter((part) => !modifierOrder.includes(part));
+    return [...modifiers, ...triggers].join('+');
+  }
+
+  function canonicalKeyFromEvent(e: KeyboardEvent): string {
+    if (e.key === 'Meta' || e.code === 'MetaLeft' || e.code === 'MetaRight') return 'cmd';
+    if (e.key === 'Control' || e.code === 'ControlLeft' || e.code === 'ControlRight') return 'ctrl';
+    if (e.key === 'Alt' || e.key === 'Option' || e.code === 'AltLeft' || e.code === 'AltRight') return 'option';
+    if (e.key === 'Shift' || e.code === 'ShiftLeft' || e.code === 'ShiftRight') return 'shift';
+    if (e.key === 'Fn' || e.key === 'fn' || e.key === 'F24') return 'fn';
+    if (isWindowsPlatform() && e.code === 'CapsLock') return 'fn';
+    if (e.code.startsWith('Key')) return e.code.slice(3).toLowerCase();
+    if (e.code.startsWith('Digit')) return e.code.slice(5);
+    if (e.code.startsWith('Numpad') && e.code.length === 7) return e.code.slice(6);
+    if (e.code.startsWith('F') && /^F\d{1,2}$/.test(e.code)) return e.code.toLowerCase();
+
+    const namedKeys: Record<string, string> = {
+      Space: 'space',
+      Enter: 'return',
+      Return: 'return',
+      Tab: 'tab',
+      Escape: 'escape',
+      Backspace: 'delete',
+      Delete: 'forwarddelete',
+      CapsLock: 'capslock',
+      ArrowLeft: 'left',
+      ArrowRight: 'right',
+      ArrowUp: 'up',
+      ArrowDown: 'down',
+      Home: 'home',
+      End: 'end',
+      PageUp: 'pageup',
+      PageDown: 'pagedown',
+      Semicolon: ';',
+      Equal: '=',
+      Comma: ',',
+      Minus: '-',
+      Period: '.',
+      Slash: '/',
+      Backquote: '`',
+      BracketLeft: '[',
+      Backslash: '\\',
+      BracketRight: ']',
+      Quote: "'",
+    };
+
+    if (namedKeys[e.code]) return namedKeys[e.code];
+    if (e.key.length === 1) return e.key.toLowerCase();
+    return '';
+  }
+
+  function isWindowsPlatform(): boolean {
+    return typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows');
   }
 
   // ── Hotkey Display ────────────────────────────────────────────────────

--- a/tauri-app/src/lib/settings/Settings.svelte
+++ b/tauri-app/src/lib/settings/Settings.svelte
@@ -101,6 +101,7 @@
   // General
   let hotkey = $state('fn');
   let capturingHotkey = $state(false);
+  let hotkeyPreview = $state('');
   let microphones = $state<string[]>([]);
   let selectedMic = $state('');
 
@@ -258,8 +259,29 @@
 
   // ── Close Window ──────────────────────────────────────────────────────
 
-  function closeWindow() {
-    getCurrentWindow().hide();
+  async function closeWindow() {
+    if (capturingHotkey) {
+      await invoke('cancel_hotkey_capture');
+    }
+    await invoke('hide_app_window', { label: 'settings' });
+  }
+
+  async function toggleHotkeyCapture() {
+    hotkeyPreview = '';
+    capturingHotkey = !capturingHotkey;
+
+    if (capturingHotkey) {
+      await invoke('start_hotkey_capture');
+    } else {
+      await invoke('cancel_hotkey_capture');
+    }
+  }
+
+  function setCapturedHotkey(value: string) {
+    hotkey = value;
+    hotkeyPreview = '';
+    capturingHotkey = false;
+    void invoke('cancel_hotkey_capture');
   }
 
   // ── Keyboard ──────────────────────────────────────────────────────────
@@ -269,15 +291,11 @@
       e.preventDefault();
       e.stopPropagation();
 
-      // Map key to supported hotkeys
-      if (e.key === 'Alt' || e.key === 'Option') {
-        hotkey = 'option';
+      if (e.key === 'Escape' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        hotkeyPreview = '';
         capturingHotkey = false;
-      } else if (e.key === 'fn' || e.key === 'F24') {
-        hotkey = 'fn';
-        capturingHotkey = false;
-      } else if (e.key === 'Escape') {
-        capturingHotkey = false;
+        void invoke('cancel_hotkey_capture');
+        return;
       }
       return;
     }
@@ -289,12 +307,43 @@
     }
   }
 
+  function onKeyUp(e: KeyboardEvent) {
+    if (!capturingHotkey) return;
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   // ── Hotkey Display ────────────────────────────────────────────────────
 
   function hotkeyDisplayLabel(key: string): string {
-    if (key === 'fn') return 'fn / Globe';
-    if (key === 'option') return 'Option';
-    return key;
+    return key
+      .split('+')
+      .filter(Boolean)
+      .map((part) => {
+        if (part === 'cmd') return 'Cmd';
+        if (part === 'ctrl') return 'Ctrl';
+        if (part === 'option') return 'Option';
+        if (part === 'shift') return 'Shift';
+        if (part === 'fn') return 'fn';
+        if (part === 'space') return 'Space';
+        if (part === 'return') return 'Return';
+        if (part === 'escape') return 'Esc';
+        if (part === 'delete') return 'Delete';
+        if (part === 'forwarddelete') return 'Forward Delete';
+        if (part === 'capslock') return 'Caps Lock';
+        if (part === 'pageup') return 'Page Up';
+        if (part === 'pagedown') return 'Page Down';
+        if (part === 'left') return 'Left';
+        if (part === 'right') return 'Right';
+        if (part === 'up') return 'Up';
+        if (part === 'down') return 'Down';
+        if (part.startsWith('keycode:')) return `Key ${part.slice('keycode:'.length)}`;
+        if (part.startsWith('vk:')) return `Key ${part.slice('vk:'.length)}`;
+        if (part.length === 1) return part.toUpperCase();
+        if (/^f\d{1,2}$/.test(part)) return part.toUpperCase();
+        return part;
+      })
+      .join('+');
   }
 
   // ── Reset Onboarding ─────────────────────────────────────────────────
@@ -337,6 +386,8 @@
   // the form always reflects the latest persisted values (the window is
   // hidden rather than destroyed when closed).
   let unlistenFocus: (() => void) | undefined;
+  let unlistenHotkeyPreview: (() => void) | undefined;
+  let unlistenHotkeyCapture: (() => void) | undefined;
 
   getCurrentWindow()
     .onFocusChanged(({ payload: focused }) => {
@@ -349,12 +400,33 @@
       unlistenFocus = fn;
     });
 
+  getCurrentWindow()
+    .listen<string>('settings:hotkey-preview', ({ payload }) => {
+      if (capturingHotkey) {
+        hotkeyPreview = payload;
+      }
+    })
+    .then((fn) => {
+      unlistenHotkeyPreview = fn;
+    });
+
+  getCurrentWindow()
+    .listen<string>('settings:hotkey-captured', ({ payload }) => {
+      setCapturedHotkey(payload);
+    })
+    .then((fn) => {
+      unlistenHotkeyCapture = fn;
+    });
+
   onDestroy(() => {
     unlistenFocus?.();
+    unlistenHotkeyPreview?.();
+    unlistenHotkeyCapture?.();
+    void invoke('cancel_hotkey_capture');
   });
 </script>
 
-<svelte:window onkeydown={onKeyDown} />
+<svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />
 
 {#if loading}
   <div class="settings-container" style="align-items: center; justify-content: center;">
@@ -375,15 +447,15 @@
             <button
               class="hotkey-button"
               class:capturing={capturingHotkey}
-              onclick={() => { capturingHotkey = !capturingHotkey; }}
+              onclick={toggleHotkeyCapture}
             >
               {#if capturingHotkey}
-                Press a key...
+                {hotkeyPreview ? hotkeyDisplayLabel(hotkeyPreview) : 'Press shortcut...'}
               {:else}
                 {hotkeyDisplayLabel(hotkey)}
               {/if}
             </button>
-            <span class="field-description">Press fn (Globe) or Option to set your recording hotkey.</span>
+            <span class="field-description">Press the exact key or combination. Fn/Globe is captured natively.</span>
           </div>
 
           <div class="field-divider"></div>

--- a/tauri-app/src/lib/settings/Settings.svelte
+++ b/tauri-app/src/lib/settings/Settings.svelte
@@ -386,7 +386,6 @@
     if (e.key === 'Alt' || e.key === 'Option' || e.code === 'AltLeft' || e.code === 'AltRight') return 'option';
     if (e.key === 'Shift' || e.code === 'ShiftLeft' || e.code === 'ShiftRight') return 'shift';
     if (e.key === 'Fn' || e.key === 'fn' || e.key === 'F24') return 'fn';
-    if (isWindowsPlatform() && e.code === 'CapsLock') return 'fn';
     if (e.code.startsWith('Key')) return e.code.slice(3).toLowerCase();
     if (e.code.startsWith('Digit')) return e.code.slice(5);
     if (e.code.startsWith('Numpad') && e.code.length === 7) return e.code.slice(6);
@@ -425,10 +424,6 @@
     if (namedKeys[e.code]) return namedKeys[e.code];
     if (e.key.length === 1) return e.key.toLowerCase();
     return '';
-  }
-
-  function isWindowsPlatform(): boolean {
-    return typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows');
   }
 
   // ── Hotkey Display ────────────────────────────────────────────────────

--- a/tauri-app/src/lib/settings/settings.css
+++ b/tauri-app/src/lib/settings/settings.css
@@ -322,7 +322,7 @@
   align-items: center;
   justify-content: center;
   height: 32px;
-  min-width: 100px;
+  min-width: 168px;
   padding: 0 14px;
   background: var(--settings-input-bg);
   border: 1px solid var(--settings-input-border);


### PR DESCRIPTION
## Summary
- move hotkey and capture callbacks off native OS input hooks
- invalidate stale listener generations when hotkey handling restarts
- map Windows fn handling to F24 so fn and fn+key use real down/up events

Refs #28

## Test plan
- [x] cargo fmt --check
- [x] npm run check
- [x] cargo check
- [x] cargo check --target x86_64-pc-windows-msvc
- [x] git diff --check
- [x] npm run tauri -- build