### PR TITLE
fix: repair overlay click targets

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6700,7 +6700,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.1.2"
+version = "2.1.3"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/sidecar-overlay/Sources/OverlayLayout.swift
+++ b/tauri-app/src-tauri/sidecar-overlay/Sources/OverlayLayout.swift
@@ -17,12 +17,20 @@ enum OverlayLayout {
     static let controlHitPadding: CGFloat = 4
     static let controlButtonSpacing: CGFloat = 49
 
-    static let activePillHitBaseY: CGFloat = 405
-    static let activePillHitWidth: CGFloat = 180
-    static let activePillHitHeight: CGFloat = 70
-    static let idlePillHitY: CGFloat = 350
-    static let idlePillHitWidth: CGFloat = 160
-    static let idlePillHitHeight: CGFloat = 70
+    static let activePillCenterY: CGFloat = 410
+    static let idlePillCenterY: CGFloat = 385
+    static let pillIdleContentWidth: CGFloat = 40
+    static let pillIdleContentHeight: CGFloat = 8
+    static let pillRegularContentWidth: CGFloat = 52
+    static let pillHandsFreeContentWidth: CGFloat = 124
+    static let pillExpandedContentHeight: CGFloat = 28
+    static let pillHorizontalPadding: CGFloat = 12
+    static let pillHandsFreeHorizontalPadding: CGFloat = 7
+    static let pillVerticalPadding: CGFloat = 6
+    static let pillIdleScale: CGFloat = 0.5
+    static let pillHoverScale: CGFloat = 0.58
+    static let pillExpandedScale: CGFloat = 0.82
+    static let pillHitPadding: CGFloat = 12
 
     static let permissionCardHitY: CGFloat = 425
     static let permissionCardHitWidth: CGFloat = 390

--- a/tauri-app/src-tauri/sidecar-overlay/Sources/OverlayPanel.swift
+++ b/tauri-app/src-tauri/sidecar-overlay/Sources/OverlayPanel.swift
@@ -1,43 +1,78 @@
 import Cocoa
 import SwiftUI
 
-// MARK: - Hit-testing
+// MARK: - Hit targets
 
-/// NSView subclass that receives first-click and forwards to a callback.
-class ClickTargetView: NSView {
-    var onClick: (() -> Void)?
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-    override func mouseDown(with event: NSEvent) { onClick?() }
-}
+/// Small transparent child panel for the few regions that should remain clickable.
+final class OverlayHitPanel: NSPanel {
+    final class HitView: NSView {
+        var onClick: ((NSPoint) -> Void)?
+        var onHover: ((Bool) -> Void)?
+        private var trackingAreaRef: NSTrackingArea?
 
-/// Content view that passes clicks through except on explicit overlay targets.
-class OverlayContentView: NSView {
-    var pillHitRegion: NSRect = .zero
-    var permissionHitRegion: NSRect = .zero
-    var onPermissionClick: (() -> Void)?
+        override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        if permissionHitRegion.contains(point) {
-            return self
+        override func updateTrackingAreas() {
+            if let trackingAreaRef {
+                removeTrackingArea(trackingAreaRef)
+            }
+            trackingAreaRef = NSTrackingArea(
+                rect: bounds,
+                options: [.activeAlways, .mouseEnteredAndExited, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(trackingAreaRef!)
+            super.updateTrackingAreas()
         }
-        for subview in subviews.reversed() {
-            guard subview is ClickTargetView else { continue }
-            let local = convert(point, to: subview)
-            if subview.bounds.contains(local) { return subview }
+
+        override func mouseEntered(with event: NSEvent) { onHover?(true) }
+        override func mouseExited(with event: NSEvent) { onHover?(false) }
+
+        override func mouseDown(with event: NSEvent) {
+            onClick?(convert(event.locationInWindow, from: nil))
         }
-        if pillHitRegion.contains(point) {
-            return super.hitTest(point)
-        }
-        return nil
     }
 
-    override func mouseDown(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        if permissionHitRegion.contains(point) {
-            onPermissionClick?()
+    let hitView = HitView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    init() {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 1, height: 1),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        level = .floating
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        ignoresMouseEvents = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        hidesOnDeactivate = false
+        hitView.wantsLayer = true
+        hitView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.01).cgColor
+        contentView = hitView
+    }
+
+    func apply(parent: NSWindow, region: NSRect) {
+        guard !region.isEmpty, parent.isVisible else {
+            orderOut(nil)
+            return
         }
+
+        let frame = NSRect(
+            x: parent.frame.minX + region.minX,
+            y: parent.frame.minY + region.minY,
+            width: region.width,
+            height: region.height
+        )
+        setFrame(frame, display: true)
+        hitView.frame = NSRect(origin: .zero, size: frame.size)
+        orderFrontRegardless()
     }
 }
 
@@ -46,9 +81,14 @@ class OverlayContentView: NSView {
 class OverlayPanel: NSPanel {
     let overlayState = OverlayState()
     private var errorDismissWork: DispatchWorkItem?
-    private var pauseTarget: ClickTargetView?
-    private var stopTarget: ClickTargetView?
-    private var contentOverlay: OverlayContentView?
+    private let pillHitPanel = OverlayHitPanel()
+    private let permissionHitPanel = OverlayHitPanel()
+    private let pauseHitPanel = OverlayHitPanel()
+    private let stopHitPanel = OverlayHitPanel()
+    private var pillHitRegion: NSRect = .zero
+    private var permissionHitRegion: NSRect = .zero
+    private var pauseHitRegion: NSRect = .zero
+    private var stopHitRegion: NSRect = .zero
 
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
@@ -72,34 +112,33 @@ class OverlayPanel: NSPanel {
         isOpaque = false
         backgroundColor = .clear
         hasShadow = false
-        ignoresMouseEvents = false
+        ignoresMouseEvents = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         isMovableByWindowBackground = false
         hidesOnDeactivate = false
-
-        let container = OverlayContentView(frame: NSRect(x: 0, y: 0, width: width, height: height))
-        container.onPermissionClick = { [weak self] in self?.overlayState.onPermissionAction?() }
-        contentOverlay = container
 
         let hostingView = NSHostingView(rootView:
             OverlayView(state: overlayState)
                 .frame(width: width, height: height)
         )
         hostingView.frame = NSRect(x: 0, y: 0, width: width, height: height)
-        container.addSubview(hostingView)
+        contentView = hostingView
 
-        let pause = ClickTargetView(frame: .zero)
-        pause.onClick = { [weak self] in self?.overlayState.onPauseResume?() }
-        container.addSubview(pause)
-        pauseTarget = pause
+        pillHitPanel.hitView.onClick = { [weak self] point in self?.handlePillHit(point) }
+        pillHitPanel.hitView.onHover = { [weak self] hovering in self?.handlePillHover(hovering) }
+        permissionHitPanel.hitView.onClick = { [weak self] _ in self?.overlayState.onPermissionAction?() }
+        pauseHitPanel.hitView.onClick = { [weak self] _ in self?.overlayState.onPauseResume?() }
+        stopHitPanel.hitView.onClick = { [weak self] _ in self?.overlayState.onStop?() }
 
-        let stop = ClickTargetView(frame: .zero)
-        stop.onClick = { [weak self] in self?.overlayState.onStop?() }
-        container.addSubview(stop)
-        stopTarget = stop
-
-        contentView = container
+        updateButtonTargets()
         updatePillTarget()
+    }
+
+    deinit {
+        pillHitPanel.orderOut(nil)
+        permissionHitPanel.orderOut(nil)
+        pauseHitPanel.orderOut(nil)
+        stopHitPanel.orderOut(nil)
     }
 
     private var onScreenFrame: NSRect {
@@ -122,18 +161,22 @@ class OverlayPanel: NSPanel {
         )
     }
 
-    private func showAtRest() {
+    func showAtRest() {
         setFrame(onScreenFrame, display: true)
         orderFront(nil)
+        updateHitPanels()
     }
 
     private func slideIn() {
         orderFront(nil)
+        updateHitPanels()
         let target = onScreenFrame
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.5
             ctx.timingFunction = CAMediaTimingFunction(controlPoints: 0.16, 1, 0.3, 1)
             animator().setFrame(target, display: true)
+        } completionHandler: { [weak self] in
+            self?.updateHitPanels()
         }
     }
 
@@ -143,6 +186,8 @@ class OverlayPanel: NSPanel {
             ctx.duration = 0.4
             ctx.timingFunction = CAMediaTimingFunction(controlPoints: 0.4, 0, 1, 1)
             animator().setFrame(target, display: true)
+        } completionHandler: { [weak self] in
+            self?.updateHitPanels()
         }
     }
 
@@ -168,7 +213,6 @@ class OverlayPanel: NSPanel {
             withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: 0.35)) {
                 overlayState.mode = .pending
             }
-            updateButtonTargets()
 
         case "recording":
             if wasIdle {
@@ -182,7 +226,6 @@ class OverlayPanel: NSPanel {
             overlayState.isHandsFree = handsFree
             overlayState.isPaused = paused
             overlayState.handsFreeElapsed = elapsed
-            updateButtonTargets()
 
         case "processing":
             overlayState.isHandsFree = false
@@ -210,6 +253,7 @@ class OverlayPanel: NSPanel {
         default:
             break
         }
+        updateButtonTargets()
         updatePillTarget()
     }
 
@@ -221,6 +265,7 @@ class OverlayPanel: NSPanel {
 
     func applyError(_ message: String) {
         overlayState.mode = .error(message)
+        updateButtonTargets()
         updatePillTarget()
         errorDismissWork?.cancel()
         let work = DispatchWorkItem { [weak self] in
@@ -244,6 +289,7 @@ class OverlayPanel: NSPanel {
                 slideOut()
             }
         }
+        updateButtonTargets()
         updatePillTarget()
     }
 
@@ -280,9 +326,11 @@ class OverlayPanel: NSPanel {
         if let label = hotkeyLabel { overlayState.hotkeyLabel = label }
         if let visible = alwaysVisible {
             overlayState.alwaysVisible = visible
-            guard overlayState.mode == .idle && overlayState.onboardingStep == nil else { return }
-            if visible { showAtRest() } else { slideOut() }
+            if overlayState.mode == .idle && overlayState.onboardingStep == nil {
+                if visible { showAtRest() } else { slideOut() }
+            }
         }
+        updatePillTarget()
     }
 
     func applyCelebrating() {
@@ -291,13 +339,50 @@ class OverlayPanel: NSPanel {
 
     // MARK: - Private
 
+    private var isMinimizedIdle: Bool {
+        overlayState.mode == .idle
+            && overlayState.permissionPrompt == nil
+            && overlayState.onboardingStep == nil
+    }
+
+    private func updateHitPanels() {
+        pillHitPanel.apply(parent: self, region: pillHitRegion)
+        permissionHitPanel.apply(parent: self, region: permissionHitRegion)
+        pauseHitPanel.apply(parent: self, region: pauseHitRegion)
+        stopHitPanel.apply(parent: self, region: stopHitRegion)
+
+        if !isMinimizedIdle, overlayState.isHovering {
+            overlayState.isHovering = false
+        }
+    }
+
+    private func handlePillHover(_ hovering: Bool) {
+        let shouldHover = hovering && isMinimizedIdle
+        if overlayState.isHovering != shouldHover {
+            withAnimation(.easeOut(duration: 0.35)) {
+                overlayState.isHovering = shouldHover
+            }
+        }
+    }
+
+    private func handlePillHit(_: NSPoint) {
+        guard overlayState.mode != .processing else { return }
+        overlayState.onClickToRecord?()
+    }
+
     private func updateButtonTargets() {
-        guard let pause = pauseTarget, let stop = stopTarget else { return }
+        guard overlayState.mode == .recording && overlayState.isHandsFree else {
+            pauseHitRegion = .zero
+            stopHitRegion = .zero
+            updateHitPanels()
+            return
+        }
+
         let cx = frame.width / 2
         let cy = OverlayLayout.controlCenterY - OverlayLayout.expandedStackYOffset
 
         let scale: CGFloat
-        if overlayState.mode == .recording && !overlayState.isPaused {
+        if !overlayState.isPaused {
             let lvl = min(CGFloat(overlayState.audioLevel), 1.0)
             scale = OverlayLayout.controlScale * (1.0 + pow(lvl, 1.5) * OverlayLayout.audioBounceScale)
         } else {
@@ -308,47 +393,96 @@ class OverlayPanel: NSPanel {
         let pauseCX = cx - OverlayLayout.controlButtonSpacing * scale
         let stopCX  = cx + OverlayLayout.controlButtonSpacing * scale
 
-        pause.frame = NSRect(x: pauseCX - targetRadius, y: cy - targetRadius,
-                             width: targetRadius * 2, height: targetRadius * 2)
-        stop.frame  = NSRect(x: stopCX - targetRadius, y: cy - targetRadius,
-                             width: targetRadius * 2, height: targetRadius * 2)
+        pauseHitRegion = NSRect(x: pauseCX - targetRadius, y: cy - targetRadius,
+                                 width: targetRadius * 2, height: targetRadius * 2)
+        stopHitRegion = NSRect(x: stopCX - targetRadius, y: cy - targetRadius,
+                                width: targetRadius * 2, height: targetRadius * 2)
+        updateHitPanels()
     }
 
     private func updatePillTarget() {
         let cx = frame.width / 2
         let isExpanded = overlayState.mode != .idle || overlayState.onboardingStep != nil || overlayState.permissionPrompt != nil
         if overlayState.permissionPrompt != nil {
-            contentOverlay?.permissionHitRegion = NSRect(
+            permissionHitRegion = NSRect(
                 x: cx - OverlayLayout.permissionCardHitWidth / 2,
                 y: OverlayLayout.permissionCardHitY,
                 width: OverlayLayout.permissionCardHitWidth,
                 height: OverlayLayout.permissionCardHitHeight
             )
         } else {
-            contentOverlay?.permissionHitRegion = .zero
+            permissionHitRegion = .zero
         }
         switch overlayState.mode {
         case .processing:
-            contentOverlay?.pillHitRegion = .zero
+            pillHitRegion = .zero
         default:
-            if isExpanded {
-                let width = OverlayLayout.activePillHitWidth
-                let y = OverlayLayout.activePillHitBaseY - OverlayLayout.expandedStackYOffset
-                contentOverlay?.pillHitRegion = NSRect(
-                    x: cx - width / 2,
-                    y: y,
-                    width: width,
-                    height: OverlayLayout.activePillHitHeight
-                )
+            if overlayState.mode == .recording && overlayState.isHandsFree {
+                pillHitRegion = .zero
             } else {
-                let width = OverlayLayout.idlePillHitWidth
-                contentOverlay?.pillHitRegion = NSRect(
-                    x: cx - width / 2,
-                    y: OverlayLayout.idlePillHitY,
-                    width: width,
-                    height: OverlayLayout.idlePillHitHeight
+                let size = pillHitSize(isExpanded: isExpanded)
+                let centerY = isExpanded ? OverlayLayout.activePillCenterY : OverlayLayout.idlePillCenterY
+                pillHitRegion = NSRect(
+                    x: cx - size.width / 2,
+                    y: centerY - size.height / 2,
+                    width: size.width,
+                    height: size.height
                 )
             }
+        }
+        updateHitPanels()
+    }
+
+    private func pillHitSize(isExpanded: Bool) -> NSSize {
+        let contentWidth: CGFloat
+        let contentHeight: CGFloat
+        let horizontalPadding: CGFloat
+        let scale: CGFloat
+
+        if isExpanded {
+            contentWidth = expandedPillContentWidth()
+            contentHeight = OverlayLayout.pillExpandedContentHeight
+            horizontalPadding = overlayState.isHandsFree
+                ? OverlayLayout.pillHandsFreeHorizontalPadding
+                : OverlayLayout.pillHorizontalPadding
+            scale = OverlayLayout.pillExpandedScale
+        } else {
+            contentWidth = OverlayLayout.pillIdleContentWidth
+            contentHeight = OverlayLayout.pillIdleContentHeight
+            horizontalPadding = OverlayLayout.pillHorizontalPadding
+            scale = overlayState.isHovering ? OverlayLayout.pillHoverScale : OverlayLayout.pillIdleScale
+        }
+
+        let width = (contentWidth + horizontalPadding * 2) * scale + OverlayLayout.pillHitPadding * 2
+        let height = (contentHeight + OverlayLayout.pillVerticalPadding * 2) * scale + OverlayLayout.pillHitPadding * 2
+        return NSSize(width: width, height: height)
+    }
+
+    private func expandedPillContentWidth() -> CGFloat {
+        guard showHoldPromptInPill else {
+            return overlayState.isHandsFree
+                ? OverlayLayout.pillHandsFreeContentWidth
+                : OverlayLayout.pillRegularContentWidth
+        }
+
+        let suffix = overlayState.onboardingStep == .welcome ? "to finish" : "to continue"
+        let font = NSFont.systemFont(ofSize: 12, weight: .medium)
+        let keyFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
+        let textWidth = ("Hold " as NSString).size(withAttributes: [.font: font]).width
+            + (overlayState.hotkeyLabel as NSString).size(withAttributes: [.font: keyFont]).width
+            + (suffix as NSString).size(withAttributes: [.font: font]).width
+        return textWidth + 20 + 6 + 24
+    }
+
+    private var showHoldPromptInPill: Bool {
+        guard let step = overlayState.onboardingStep, overlayState.mode == .idle || overlayState.mode == .noSpeech else {
+            return false
+        }
+        switch step {
+        case .apiTip, .formattingTip, .welcome:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/tauri-app/src-tauri/sidecar-overlay/Sources/main.swift
+++ b/tauri-app/src-tauri/sidecar-overlay/Sources/main.swift
@@ -13,8 +13,8 @@ panel.overlayState.onPermissionAction = { sendEvent("permission_action") }
 panel.overlayState.onPauseResume = { sendEvent("pause") }
 panel.overlayState.onStop = { sendEvent("stop") }
 
-// Show the panel (starts hidden or visible based on default alwaysVisible=true)
-panel.orderFront(nil)
+// Show the panel through OverlayPanel so its frame and click targets stay in sync.
+panel.showAtRest()
 
 // -- stdin reader (background thread) --
 let decoder = JSONDecoder()

--- a/tauri-app/src-tauri/src/win_overlay.rs
+++ b/tauri-app/src-tauri/src/win_overlay.rs
@@ -74,9 +74,10 @@ const IDLE_CONTENT_W: f32 = 64.0; // 40px empty target + 12px horizontal padding
 const HANDS_FREE_CONTENT_W: f32 = 138.0; // 124px controls + 7px horizontal padding on each side.
 const EXPANDED_PILL_H: f32 = 40.0;
 const IDLE_PILL_H: f32 = 20.0;
-const PILL_HIT_PADDING: f32 = 12.0;
+const PILL_HIT_PADDING: f32 = 12.0; // Keep in sync with macOS OverlayLayout.pillHitPadding.
 const CONTROL_BUTTON_OFFSET: f32 = 49.0;
 const CONTROL_HIT_RADIUS: f32 = 17.0;
+const CONTROL_HIT_PADDING: f32 = 8.0;
 const GRADIENT_OFFSET_Y: f32 = 18.0;
 const GRADIENT_MOTION_SCALE: f32 = 0.38;
 const GRADIENT_DITHER_ALPHA: f32 = 3.0;
@@ -1093,7 +1094,8 @@ fn hit_target_from_current_geometry(point: POINT) -> Option<HitTarget> {
             CONTROL_BUTTON_OFFSET * geom.content_scale * hands_free_hit_progress(&state, &geom);
         let pause_cx = geom.content_cx - button_offset;
         let stop_cx = geom.content_cx + button_offset;
-        let control_hit_radius = CONTROL_HIT_RADIUS * geom.content_scale.max(0.75) + 8.0;
+        let control_hit_radius =
+            CONTROL_HIT_RADIUS * geom.content_scale.max(0.75) + CONTROL_HIT_PADDING;
 
         if distance(x, y, pause_cx, geom.pill_cy) <= control_hit_radius {
             return Some(HitTarget::Pause);

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- keep the macOS overlay background click-through while routing only real controls through small hit panels
- sync macOS startup positioning through the overlay panel API so the pill and hit targets do not drift
- align Windows hit constants with the same pill/control margin model
- bump Yap to v2.1.3 for this bugfix release

## Test plan
- [x] swift build (tauri-app/src-tauri/sidecar-overlay)
- [x] npm run check (tauri-app)
- [x] cargo check (tauri-app/src-tauri)
- [x] cargo fmt --check (tauri-app/src-tauri)
- [x] npm run tauri -- build (tauri-app)

Note: local macOS Windows-target check is blocked by missing llvm-rc; the PR's Windows runner performs the actual Windows build.