### PR TITLE
feat: add press enter after paste setting

### DIFF
--- a/tauri-app/src-tauri/src/config.rs
+++ b/tauri-app/src-tauri/src/config.rs
@@ -19,6 +19,10 @@ pub struct AppConfig {
     #[serde(default)]
     pub audio_device: String,
 
+    /// Press Return/Enter after pasting the transcription.
+    #[serde(default)]
+    pub press_enter_after_paste: bool,
+
     /// Transcription provider
     #[serde(default)]
     pub tx_provider: TranscriptionProvider,
@@ -137,6 +141,7 @@ impl Default for AppConfig {
         Self {
             hotkey: default_hotkey(),
             audio_device: String::new(),
+            press_enter_after_paste: false,
             tx_provider: TranscriptionProvider::default(),
             tx_api_key: String::new(),
             tx_model: String::new(),

--- a/tauri-app/src-tauri/src/orchestrator.rs
+++ b/tauri-app/src-tauri/src/orchestrator.rs
@@ -1263,7 +1263,7 @@ impl Orchestrator {
                         }
 
                         // Paste the result
-                        if let Err(e) = paste::paste_text(&text) {
+                        if let Err(e) = paste::paste_text(&text, cfg.press_enter_after_paste) {
                             log::info(&format!("Paste failed: {e}"));
                         }
                     }

--- a/tauri-app/src-tauri/src/paste.rs
+++ b/tauri-app/src-tauri/src/paste.rs
@@ -2,7 +2,8 @@ use std::thread;
 use std::time::Duration;
 
 /// Write `text` to the system clipboard, simulate Cmd+V (macOS) or Ctrl+V
-/// (Windows), then restore the previous clipboard contents.
+/// (Windows), optionally press Return/Enter, then restore the previous
+/// clipboard contents.
 ///
 /// Sequence (from spec):
 ///   1. Save current clipboard string
@@ -10,8 +11,9 @@ use std::time::Duration;
 ///   3. Wait 50 ms
 ///   4. Simulate paste keystroke
 ///   5. Wait 300 ms
-///   6. Restore previous clipboard (or leave empty)
-pub fn paste_text(text: &str) -> Result<(), String> {
+///   6. Optionally simulate Return/Enter
+///   7. Restore previous clipboard (or leave empty)
+pub fn paste_text(text: &str, press_enter_after_paste: bool) -> Result<(), String> {
     // --- Step 1: Save previous clipboard ---
     let mut clipboard = arboard::Clipboard::new().map_err(|e| e.to_string())?;
     let previous = clipboard.get_text().ok();
@@ -30,7 +32,13 @@ pub fn paste_text(text: &str) -> Result<(), String> {
     // --- Step 5: Wait for paste to complete ---
     thread::sleep(Duration::from_millis(300));
 
-    // --- Step 6: Restore previous clipboard ---
+    // --- Step 6: Optionally submit after paste ---
+    if press_enter_after_paste {
+        simulate_enter()?;
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    // --- Step 7: Restore previous clipboard ---
     match previous {
         Some(prev) => clipboard.set_text(prev).map_err(|e| e.to_string())?,
         None => clipboard.clear().map_err(|e| e.to_string())?,
@@ -68,6 +76,28 @@ fn simulate_paste() -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+fn simulate_enter() -> Result<(), String> {
+    use core_graphics::event::{CGEvent, CGEventTapLocation, CGKeyCode};
+    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+
+    let source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState)
+        .map_err(|_| "failed to create CGEventSource".to_string())?;
+
+    // Virtual key 0x24 = Return on macOS.
+    let return_keycode: CGKeyCode = 0x24;
+
+    let key_down = CGEvent::new_keyboard_event(source.clone(), return_keycode, true)
+        .map_err(|_| "failed to create key down event".to_string())?;
+    let key_up = CGEvent::new_keyboard_event(source, return_keycode, false)
+        .map_err(|_| "failed to create key up event".to_string())?;
+
+    key_down.post(CGEventTapLocation::AnnotatedSession);
+    key_up.post(CGEventTapLocation::AnnotatedSession);
+
+    Ok(())
+}
+
 #[cfg(target_os = "windows")]
 fn simulate_paste() -> Result<(), String> {
     use enigo::{Direction, Enigo, Key, Keyboard, Settings};
@@ -83,6 +113,18 @@ fn simulate_paste() -> Result<(), String> {
         .map_err(|e| e.to_string())?;
     enigo
         .key(Key::Control, Direction::Release)
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn simulate_enter() -> Result<(), String> {
+    use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+
+    let mut enigo = Enigo::new(&Settings::default()).map_err(|e| e.to_string())?;
+    enigo
+        .key(Key::Return, Direction::Click)
         .map_err(|e| e.to_string())?;
 
     Ok(())

--- a/tauri-app/src/lib/settings/Settings.svelte
+++ b/tauri-app/src/lib/settings/Settings.svelte
@@ -17,6 +17,7 @@
   interface AppConfig {
     hotkey: string;
     audioDevice: string;
+    pressEnterAfterPaste: boolean;
     txProvider: string;
     txApiKey: string;
     txModel: string;
@@ -112,6 +113,7 @@
   let webLastHotkey = '';
   let microphones = $state<string[]>([]);
   let selectedMic = $state('');
+  let pressEnterAfterPaste = $state(false);
 
   // Transcription
   let txProvider = $state(defaultTxProvider);
@@ -197,6 +199,7 @@
       const cfg = await invoke<AppConfig>('get_config');
       hotkey = cfg.hotkey;
       selectedMic = cfg.audioDevice ?? '';
+      pressEnterAfterPaste = cfg.pressEnterAfterPaste ?? false;
       txProvider = isWindows && cfg.txProvider === 'none' ? defaultTxProvider : cfg.txProvider;
       txApiKey = cfg.txApiKey;
       txModel = cfg.txModel;
@@ -246,6 +249,7 @@
       const cfg: AppConfig = {
         hotkey,
         audioDevice: selectedMic,
+        pressEnterAfterPaste,
         txProvider,
         txApiKey,
         txModel,
@@ -490,6 +494,7 @@
   function resetDefaults() {
     hotkey = defaultHotkey;
     selectedMic = '';
+    pressEnterAfterPaste = false;
     txProvider = defaultTxProvider;
     txApiKey = '';
     txModel = '';
@@ -597,6 +602,20 @@
                 ? 'Press the exact key or combination. Fn works only on keyboards that expose it to Windows.'
                 : 'Press the exact key or combination. Fn/Globe is captured natively.'}
             </span>
+          </div>
+
+          <div class="field-divider"></div>
+
+          <div class="toggle-row">
+            <div class="toggle-info">
+              <span class="toggle-label">Press Enter after paste</span>
+              <span class="toggle-description">Send Return after Yap inserts the transcription</span>
+            </div>
+            <label class="toggle-switch">
+              <input type="checkbox" bind:checked={pressEnterAfterPaste} />
+              <span class="toggle-track"></span>
+              <span class="toggle-thumb"></span>
+            </label>
           </div>
 
           <div class="field-divider"></div>


### PR DESCRIPTION
## Summary
- add a persisted `pressEnterAfterPaste` setting
- expose the toggle in General settings
- send Return/Enter after paste when the setting is enabled

## Test plan
- [x] npm run check
- [x] npm run build
- [x] cargo check
- [x] manual dev test confirmed paste then Enter behavior

Note: `cargo check --target x86_64-pc-windows-msvc` was attempted locally but this macOS environment is missing `llvm-rc` for `tauri-winres`.