### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6700,7 +6700,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.1.3"
+version = "2.2.0"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Yap app metadata from 2.1.3 to 2.2.0
- update npm, Cargo, and Tauri version files before tagging the release

## Test plan
- [x] npm run check
- [x] cargo check
- [x] npm run build
- [x] npm run tauri -- build