### PR TITLE
feat: add signed in-app updates

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -76,8 +76,17 @@ jobs:
           node -e "require('fs').rmSync('src-tauri/target/release/bundle', { recursive: true, force: true })"
 
       - name: Build Tauri app
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         working-directory: tauri-app
         run: npx tauri build
+
+      - name: Build signed updater release
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: tauri-app
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npx tauri build --config src-tauri/tauri.updater.conf.json
 
       - name: Upload macOS artifacts
         if: matrix.platform == 'macos-latest'
@@ -87,6 +96,8 @@ jobs:
           path: |
             tauri-app/src-tauri/target/release/bundle/dmg/*.dmg
             tauri-app/src-tauri/target/release/bundle/macos/*.app
+            tauri-app/src-tauri/target/release/bundle/macos/*.app.tar.gz
+            tauri-app/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
           if-no-files-found: error
 
       - name: Upload Windows artifacts
@@ -96,7 +107,9 @@ jobs:
           name: yap-windows
           path: |
             tauri-app/src-tauri/target/release/bundle/msi/*.msi
+            tauri-app/src-tauri/target/release/bundle/msi/*.msi.sig
             tauri-app/src-tauri/target/release/bundle/nsis/*.exe
+            tauri-app/src-tauri/target/release/bundle/nsis/*.exe.sig
           if-no-files-found: error
 
   release:
@@ -119,6 +132,67 @@ jobs:
           name: yap-windows
           path: artifacts/windows
 
+      - name: Generate updater manifest
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const tag = process.env.GITHUB_REF_NAME;
+          const repo = process.env.GITHUB_REPOSITORY;
+          const version = tag.replace(/^v/, '');
+
+          function filesUnder(dir) {
+            if (!fs.existsSync(dir)) return [];
+            return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+              const fullPath = path.join(dir, entry.name);
+              return entry.isDirectory() ? filesUnder(fullPath) : [fullPath];
+            });
+          }
+
+          function requireFile(dir, predicate, label) {
+            const file = filesUnder(dir).find(predicate);
+            if (!file) throw new Error(`Missing ${label}`);
+            return file;
+          }
+
+          function signatureFor(file) {
+            const signaturePath = `${file}.sig`;
+            if (!fs.existsSync(signaturePath)) {
+              throw new Error(`Missing signature for ${path.basename(file)}`);
+            }
+            return fs.readFileSync(signaturePath, 'utf8').trim();
+          }
+
+          function releaseUrl(file) {
+            return `https://github.com/${repo}/releases/download/${tag}/${encodeURIComponent(path.basename(file))}`;
+          }
+
+          const macBundle = requireFile('artifacts/macos', (file) => file.endsWith('.app.tar.gz'), 'macOS updater bundle');
+          const winBundle = requireFile('artifacts/windows', (file) => file.endsWith('.exe'), 'Windows updater installer');
+
+          const manifest = {
+            version,
+            notes: '',
+            pub_date: new Date().toISOString(),
+            platforms: {
+              'darwin-aarch64': {
+                signature: signatureFor(macBundle),
+                url: releaseUrl(macBundle),
+              },
+              'windows-x86_64': {
+                signature: signatureFor(winBundle),
+                url: releaseUrl(winBundle),
+              },
+            },
+          };
+
+          fs.writeFileSync('artifacts/latest.json', `${JSON.stringify(manifest, null, 2)}\n`);
+          NODE
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -126,5 +200,10 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/macos/**/*.dmg
+            artifacts/macos/**/*.app.tar.gz
+            artifacts/macos/**/*.app.tar.gz.sig
             artifacts/windows/**/*.msi
+            artifacts/windows/**/*.msi.sig
             artifacts/windows/**/*.exe
+            artifacts/windows/**/*.exe.sig
+            artifacts/latest.json

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "yap",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
-        "@tauri-apps/plugin-opener": "^2"
+        "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.6",
@@ -1246,6 +1248,24 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@types/cookie": {

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {
@@ -16,7 +16,9 @@
     "@tauri-apps/api": "2.10.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "overrides": {
     "cookie": "0.7.2"

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +933,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1329,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2623,6 +2653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +2972,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,6 +3129,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3800,15 +3862,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3921,10 +3988,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3935,6 +4015,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4663,6 +4770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4876,6 +4994,49 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -5852,6 +6013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6764,6 +6934,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xkbcommon"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6782,7 +6962,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -6808,6 +6988,8 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tiny-skia",
  "tokio",
  "uuid",
@@ -6976,6 +7158,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.3.0"
+version = "2.3.1"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"
@@ -59,6 +59,8 @@ once_cell = "1"
 fontdue = "0.9"
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2.10.1"
+tauri-plugin-process = "2.3.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"

--- a/tauri-app/src-tauri/capabilities/default.json
+++ b/tauri-app/src-tauri/capabilities/default.json
@@ -25,6 +25,8 @@
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled",
-    "dialog:default"
+    "dialog:default",
+    "process:default",
+    "updater:default"
   ]
 }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -116,6 +116,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             None,
@@ -126,6 +127,7 @@ pub fn run() {
             // the hotkey listener, sets up the tray, and begins the
             // audio level poller.
             let handle = app.handle().clone();
+            handle.plugin(tauri_plugin_updater::Builder::new().build())?;
             orchestrator::init(&handle);
             windows::hide_app_if_no_windows_visible(&handle);
 

--- a/tauri-app/src-tauri/src/tray.rs
+++ b/tauri-app/src-tauri/src/tray.rs
@@ -38,6 +38,10 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
         .build(app)
         .map_err(|e| format!("failed to create settings item: {e}"))?;
 
+    let updates_item = MenuItemBuilder::with_id("updates", "Check for Updates...")
+        .build(app)
+        .map_err(|e| format!("failed to create updates item: {e}"))?;
+
     let quit_item = MenuItemBuilder::with_id("quit", "Quit")
         .build(app)
         .map_err(|e| format!("failed to create quit item: {e}"))?;
@@ -50,6 +54,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
         .item(&enabled_item)
         .item(&history_submenu)
         .item(&settings_item)
+        .item(&updates_item)
         .separator()
         .item(&quit_item)
         .build()
@@ -74,6 +79,10 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
                 }
                 "settings" => {
                     let _ = windows::show_app_window(app, "settings");
+                }
+                "updates" => {
+                    let _ = windows::show_app_window(app, "settings");
+                    let _ = app.emit_to("settings", "settings:show-updates", ());
                 }
                 "show_history" => {
                     let _ = windows::show_app_window(app, "settings");
@@ -187,17 +196,24 @@ pub fn refresh_history_menu(app: &AppHandle) {
                 .checked(true)
                 .build(app);
             let settings_item = MenuItemBuilder::with_id("settings", "Open Yap...").build(app);
+            let updates_item =
+                MenuItemBuilder::with_id("updates", "Check for Updates...").build(app);
             let quit_item = MenuItemBuilder::with_id("quit", "Quit").build(app);
 
-            if let (Ok(title), Ok(enabled), Ok(settings), Ok(quit)) =
-                (title_item, enabled_item, settings_item, quit_item)
-            {
+            if let (Ok(title), Ok(enabled), Ok(settings), Ok(updates), Ok(quit)) = (
+                title_item,
+                enabled_item,
+                settings_item,
+                updates_item,
+                quit_item,
+            ) {
                 if let Ok(menu) = MenuBuilder::new(app)
                     .item(&title)
                     .separator()
                     .item(&enabled)
                     .item(&history_submenu)
                     .item(&settings)
+                    .item(&updates)
                     .separator()
                     .item(&quit)
                     .build()

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -51,6 +51,17 @@
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper"
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJGMUU2RTZGQzY4RjFFOEYKUldTUEhvL0diMjRlTDFuc0dDTjNHRVpmR01UQWRBaEs2bE9WclJGN0d6S2crWDBwUmoxNlA4cnoK",
+      "endpoints": [
+        "https://github.com/oobagi/yap/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
       }
     }
   }

--- a/tauri-app/src-tauri/tauri.updater.conf.json
+++ b/tauri-app/src-tauri/tauri.updater.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/tauri-app/src/lib/settings/Settings.svelte
+++ b/tauri-app/src/lib/settings/Settings.svelte
@@ -2,7 +2,7 @@
   /**
    * Full settings UI for the Yap Tauri app.
    *
-   * Sections: General, Transcription, Formatting, Behavior, History, Advanced
+   * Sections: General, Transcription, Formatting, History, Advanced
    * Loads/saves config via Tauri invoke commands.
    * Dark theme matching the overlay pill aesthetic.
    */
@@ -12,6 +12,7 @@
   import { confirm as confirmDialog } from '@tauri-apps/plugin-dialog';
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import { onDestroy } from 'svelte';
+  import type { DownloadEvent, Update } from '@tauri-apps/plugin-updater';
 
   // ── Config Shape (matches Rust AppConfig with camelCase serde) ─────────
 
@@ -134,15 +135,15 @@
     groq: 'Groq',
   };
 
-  type SectionId = 'general' | 'transcription' | 'formatting' | 'behavior' | 'history' | 'advanced';
+  type SectionId = 'general' | 'transcription' | 'formatting' | 'history' | 'advanced';
+  type UpdateStatus = 'idle' | 'checking' | 'available' | 'upToDate' | 'downloading' | 'ready' | 'error';
 
   const settingsSections: Array<{ id: SectionId; label: string; description: string }> = [
-    { id: 'general', label: 'General', description: 'Shortcut and microphone' },
+    { id: 'general', label: 'General', description: 'Shortcut, microphone, and behavior' },
     { id: 'transcription', label: 'Transcription', description: 'Provider, model, and accuracy' },
     { id: 'formatting', label: 'Formatting', description: 'Cleanup provider and style' },
-    { id: 'behavior', label: 'Behavior', description: 'Paste, audio, and launch' },
     { id: 'history', label: 'History', description: 'Saved transcripts' },
-    { id: 'advanced', label: 'Advanced', description: 'Onboarding and reset' },
+    { id: 'advanced', label: 'Advanced', description: 'Updates and reset' },
   ];
 
   // ── State ─────────────────────────────────────────────────────────────
@@ -224,6 +225,14 @@
 
   // Advanced
   let onboardingComplete = $state(false);
+
+  // Updates
+  let updateStatus = $state<UpdateStatus>('idle');
+  let updateMessage = $state('Check for a signed Yap release from GitHub.');
+  let updateVersion = $state('');
+  let updateDownloaded = $state(0);
+  let updateTotal = $state<number | null>(null);
+  let pendingUpdate: Update | null = null;
 
   // ── Derived ───────────────────────────────────────────────────────────
 
@@ -744,6 +753,112 @@
     }
   }
 
+  // ── Updates ───────────────────────────────────────────────────────────
+
+  function updateBusy(): boolean {
+    return updateStatus === 'checking' || updateStatus === 'downloading' || updateStatus === 'ready';
+  }
+
+  function updateProgress(): number {
+    if (updateStatus === 'ready') return 100;
+    if (!updateTotal || updateTotal <= 0) return 0;
+    return Math.max(0, Math.min(100, Math.round((updateDownloaded / updateTotal) * 100)));
+  }
+
+  function updateProgressLabel(): string {
+    if (updateStatus === 'ready') return 'Installed';
+    if (!updateTotal) return formatBytes(updateDownloaded);
+    return `${formatBytes(updateDownloaded)} of ${formatBytes(updateTotal)}`;
+  }
+
+  function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB';
+    const megabytes = bytes / 1024 / 1024;
+    if (megabytes < 10) return `${megabytes.toFixed(1)} MB`;
+    return `${Math.round(megabytes)} MB`;
+  }
+
+  function updaterErrorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('latest.json') || message.includes('release JSON')) {
+      return 'No signed update feed is available yet. Try again after the next release finishes.';
+    }
+    if (message.includes('signature')) {
+      return 'The update could not be verified, so Yap did not install it.';
+    }
+    return message || 'Update failed.';
+  }
+
+  async function checkForUpdates() {
+    if (!isTauriRuntime || updateBusy()) return;
+
+    pendingUpdate = null;
+    updateVersion = '';
+    updateDownloaded = 0;
+    updateTotal = null;
+    updateStatus = 'checking';
+    updateMessage = 'Checking for updates...';
+
+    try {
+      const { check } = await import('@tauri-apps/plugin-updater');
+      const update = await check({ timeout: 30000 });
+
+      if (!update) {
+        updateStatus = 'upToDate';
+        updateMessage = 'Yap is up to date.';
+        return;
+      }
+
+      pendingUpdate = update;
+      updateVersion = update.version;
+      updateStatus = 'available';
+      updateMessage = `Yap ${update.version} is ready to install.`;
+    } catch (error) {
+      pendingUpdate = null;
+      updateStatus = 'error';
+      updateMessage = updaterErrorMessage(error);
+      console.error('Failed to check for updates:', error);
+    }
+  }
+
+  async function installUpdate() {
+    if (!pendingUpdate || updateBusy()) return;
+
+    const version = pendingUpdate.version;
+    const confirmed = await confirmAction(
+      `Install Yap ${version}? Yap will restart after the update finishes.`,
+      'Install'
+    );
+    if (!confirmed || !pendingUpdate) return;
+
+    updateStatus = 'downloading';
+    updateDownloaded = 0;
+    updateTotal = null;
+    updateMessage = `Downloading Yap ${version}...`;
+
+    try {
+      const update = pendingUpdate;
+      await update.downloadAndInstall((event: DownloadEvent) => {
+        if (event.event === 'Started') {
+          updateTotal = event.data.contentLength ?? null;
+          updateDownloaded = 0;
+        } else if (event.event === 'Progress') {
+          updateDownloaded += event.data.chunkLength;
+        } else if (event.event === 'Finished') {
+          updateStatus = 'ready';
+          updateMessage = 'Update installed. Restarting Yap...';
+        }
+      });
+
+      const { relaunch } = await import('@tauri-apps/plugin-process');
+      await relaunch();
+    } catch (error) {
+      updateStatus = 'error';
+      updateMessage = updaterErrorMessage(error);
+      console.error('Failed to install update:', error);
+    }
+  }
+
   // ── Reset Onboarding ─────────────────────────────────────────────────
 
   async function confirmAction(message: string, okLabel: string): Promise<boolean> {
@@ -823,6 +938,7 @@
   let unlistenHotkeyPreview: (() => void) | undefined;
   let unlistenHotkeyCapture: (() => void) | undefined;
   let unlistenShowHistory: (() => void) | undefined;
+  let unlistenShowUpdates: (() => void) | undefined;
   let unlistenHistoryCleared: (() => void) | undefined;
 
   if (isTauriRuntime) {
@@ -872,6 +988,15 @@
       });
 
     getCurrentWindow()
+      .listen('settings:show-updates', () => {
+        activeSection = 'advanced';
+        void checkForUpdates();
+      })
+      .then((fn) => {
+        unlistenShowUpdates = fn;
+      });
+
+    getCurrentWindow()
       .listen('tray:history-cleared', () => {
         if (activeSection === 'history' || historyLoadStarted) {
           void loadHistory();
@@ -887,6 +1012,7 @@
     unlistenHotkeyPreview?.();
     unlistenHotkeyCapture?.();
     unlistenShowHistory?.();
+    unlistenShowUpdates?.();
     unlistenHistoryCleared?.();
     if (saveTimer) clearTimeout(saveTimer);
     for (const timeout of copyTimeouts.values()) {
@@ -995,6 +1121,90 @@
                     <option value="">No devices found</option>
                   {/if}
                 </select>
+              </div>
+
+              <div class="field-divider"></div>
+
+              <div class="toggle-row">
+                <div class="toggle-info">
+                  <span class="toggle-label">Start with system</span>
+                  <span class="toggle-description">Launch Yap automatically when you log in</span>
+                </div>
+                <label class="toggle-switch">
+                  <input type="checkbox" bind:checked={startWithSystem} onchange={() => { void toggleAutostart(startWithSystem); }} />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-thumb"></span>
+                </label>
+              </div>
+
+              <div class="field-divider"></div>
+
+              <div class="toggle-row">
+                <div class="toggle-info">
+                  <span class="toggle-label">Press Enter after paste</span>
+                  <span class="toggle-description">Send Return after Yap inserts the transcription</span>
+                </div>
+                <label class="toggle-switch">
+                  <input type="checkbox" bind:checked={pressEnterAfterPaste} />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-thumb"></span>
+                </label>
+              </div>
+
+              <div class="field-divider"></div>
+
+              <div class="toggle-row">
+                <div class="toggle-info">
+                  <span class="toggle-label">Sound effects</span>
+                  <span class="toggle-description">Play cues for recording, completion, and errors</span>
+                </div>
+                <label class="toggle-switch">
+                  <input type="checkbox" bind:checked={soundsEnabled} />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-thumb"></span>
+                </label>
+              </div>
+
+              <div class="field-divider"></div>
+
+              <div class="toggle-row">
+                <div class="toggle-info">
+                  <span class="toggle-label">Quiet background audio</span>
+                  <span class="toggle-description">Reduce or mute other app audio while recording</span>
+                </div>
+                <label class="toggle-switch">
+                  <input type="checkbox" bind:checked={quietAudioWhileRecording} />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-thumb"></span>
+                </label>
+              </div>
+
+              <div class="field-divider"></div>
+
+              <div class="toggle-row">
+                <div class="toggle-info">
+                  <span class="toggle-label">Gradient background</span>
+                  <span class="toggle-description">Show the animated gradient in the overlay pill</span>
+                </div>
+                <label class="toggle-switch">
+                  <input type="checkbox" bind:checked={gradientEnabled} />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-thumb"></span>
+                </label>
+              </div>
+
+              <div class="field-divider"></div>
+
+              <div class="toggle-row">
+                <div class="toggle-info">
+                  <span class="toggle-label">Always-visible pill</span>
+                  <span class="toggle-description">Keep the overlay pill visible even when idle</span>
+                </div>
+                <label class="toggle-switch">
+                  <input type="checkbox" bind:checked={alwaysVisiblePill} />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-thumb"></span>
+                </label>
               </div>
             </div>
           </section>
@@ -1257,94 +1467,6 @@
           </section>
         {/if}
 
-        {#if activeSection === 'behavior'}
-          <section class="settings-section" aria-label="Behavior settings">
-            <div class="section-body">
-              <div class="toggle-row">
-                <div class="toggle-info">
-                  <span class="toggle-label">Press Enter after paste</span>
-                  <span class="toggle-description">Send Return after Yap inserts the transcription</span>
-                </div>
-                <label class="toggle-switch">
-                  <input type="checkbox" bind:checked={pressEnterAfterPaste} />
-                  <span class="toggle-track"></span>
-                  <span class="toggle-thumb"></span>
-                </label>
-              </div>
-
-              <div class="field-divider"></div>
-
-              <div class="toggle-row">
-                <div class="toggle-info">
-                  <span class="toggle-label">Sound effects</span>
-                  <span class="toggle-description">Play cues for recording, completion, and errors</span>
-                </div>
-                <label class="toggle-switch">
-                  <input type="checkbox" bind:checked={soundsEnabled} />
-                  <span class="toggle-track"></span>
-                  <span class="toggle-thumb"></span>
-                </label>
-              </div>
-
-              <div class="field-divider"></div>
-
-              <div class="toggle-row">
-                <div class="toggle-info">
-                  <span class="toggle-label">Quiet background audio</span>
-                  <span class="toggle-description">Reduce or mute other app audio while recording</span>
-                </div>
-                <label class="toggle-switch">
-                  <input type="checkbox" bind:checked={quietAudioWhileRecording} />
-                  <span class="toggle-track"></span>
-                  <span class="toggle-thumb"></span>
-                </label>
-              </div>
-
-              <div class="field-divider"></div>
-
-              <div class="toggle-row">
-                <div class="toggle-info">
-                  <span class="toggle-label">Gradient background</span>
-                  <span class="toggle-description">Show the animated gradient in the overlay pill</span>
-                </div>
-                <label class="toggle-switch">
-                  <input type="checkbox" bind:checked={gradientEnabled} />
-                  <span class="toggle-track"></span>
-                  <span class="toggle-thumb"></span>
-                </label>
-              </div>
-
-              <div class="field-divider"></div>
-
-              <div class="toggle-row">
-                <div class="toggle-info">
-                  <span class="toggle-label">Always-visible pill</span>
-                  <span class="toggle-description">Keep the overlay pill visible even when idle</span>
-                </div>
-                <label class="toggle-switch">
-                  <input type="checkbox" bind:checked={alwaysVisiblePill} />
-                  <span class="toggle-track"></span>
-                  <span class="toggle-thumb"></span>
-                </label>
-              </div>
-
-              <div class="field-divider"></div>
-
-              <div class="toggle-row">
-                <div class="toggle-info">
-                  <span class="toggle-label">Start with system</span>
-                  <span class="toggle-description">Launch Yap automatically when you log in</span>
-                </div>
-                <label class="toggle-switch">
-                  <input type="checkbox" bind:checked={startWithSystem} onchange={() => { void toggleAutostart(startWithSystem); }} />
-                  <span class="toggle-track"></span>
-                  <span class="toggle-thumb"></span>
-                </label>
-              </div>
-            </div>
-          </section>
-        {/if}
-
         {#if activeSection === 'history'}
           <section class="settings-section" aria-label="History settings">
             <div class="section-body">
@@ -1454,6 +1576,46 @@
         {#if activeSection === 'advanced'}
           <section class="settings-section" aria-label="Advanced settings">
             <div class="section-body">
+              <div class="action-row">
+                <div class="field-copy">
+                  <span class="field-label">Software updates</span>
+                  <span class="field-description">{updateMessage}</span>
+                </div>
+                {#if updateStatus === 'available'}
+                  <button class="btn btn-primary" onclick={installUpdate} type="button">
+                    Install Update
+                  </button>
+                {:else}
+                  <button class="btn btn-secondary" onclick={checkForUpdates} type="button" disabled={updateBusy()}>
+                    {updateStatus === 'checking' ? 'Checking...' : 'Check for Updates'}
+                  </button>
+                {/if}
+              </div>
+
+              {#if updateStatus === 'downloading' || updateStatus === 'ready'}
+                <div class="update-progress" aria-label="Update progress">
+                  <div class="update-progress-header">
+                    <span>{updateStatus === 'ready' ? 'Installed' : 'Downloading'}</span>
+                    <span>{updateProgressLabel()}</span>
+                  </div>
+                  <div class="update-progress-track">
+                    <div class="update-progress-fill" style={`width: ${updateProgress()}%`}></div>
+                  </div>
+                </div>
+              {/if}
+
+              {#if updateStatus === 'available' && updateVersion}
+                <div class="section-footer">
+                  Version {updateVersion} will be verified before it is installed.
+                </div>
+              {:else if updateStatus === 'error'}
+                <div class="section-footer update-error">
+                  Yap did not install anything.
+                </div>
+              {/if}
+
+              <div class="field-divider"></div>
+
               <div class="action-row">
                 <div class="field-copy">
                   <span class="field-label">Onboarding</span>

--- a/tauri-app/src/lib/settings/settings.css
+++ b/tauri-app/src/lib/settings/settings.css
@@ -606,6 +606,17 @@ button {
   background: var(--settings-surface-hover);
 }
 
+.btn-primary {
+  border-color: var(--settings-primary);
+  background: var(--settings-primary);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  border-color: var(--settings-primary-hover);
+  background: var(--settings-primary-hover);
+}
+
 .btn-danger {
   color: #e05555;
 }
@@ -744,6 +755,39 @@ button {
   color: CanvasText;
   font-size: 13px;
   font-weight: 600;
+}
+
+.update-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 2px;
+}
+
+.update-progress-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--settings-text-muted);
+  font-size: 12px;
+}
+
+.update-progress-track {
+  overflow: hidden;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--settings-surface);
+}
+
+.update-progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--settings-primary);
+  transition: width 140ms ease;
+}
+
+.update-error {
+  color: #e05555;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- add Tauri updater and process plugins for signed in-app updates
- generate signed updater artifacts and latest.json during tag releases
- add Check for Updates in the tray and fold update controls into Advanced settings
- simplify settings by merging Behavior into General

## Test plan
- [x] npm run check
- [x] cargo fmt --check
- [x] cargo check
- [x] npm run build
- [x] npm run tauri -- build
- [x] local updater harness verified manually