### PR TITLE
fix: poll for Accessibility permission grants

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6962,7 +6962,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.3.1"
+version = "2.3.2"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/src/orchestrator.rs
+++ b/tauri-app/src-tauri/src/orchestrator.rs
@@ -426,28 +426,27 @@ impl Orchestrator {
     }
 
     pub fn on_hotkey_permission_required(&self, hotkey_label: String) {
-        let mut inner = self.inner.lock().unwrap();
-        log::info(&format!(
-            "Accessibility permission required for hotkey: {hotkey_label}"
-        ));
-        inner.state = AppState::Idle;
-        inner.hold_confirm_start = None;
-        inner.permission_prompt = Some(PermissionPromptKind::Accessibility);
-        inner.emit_state();
-        inner.emit_permission_prompt();
+        {
+            let mut inner = self.inner.lock().unwrap();
+            log::info(&format!(
+                "Accessibility permission required for hotkey: {hotkey_label}"
+            ));
+            inner.state = AppState::Idle;
+            inner.hold_confirm_start = None;
+            inner.permission_prompt = Some(PermissionPromptKind::Accessibility);
+            inner.emit_state();
+            inner.emit_permission_prompt();
+        }
+
+        #[cfg(target_os = "macos")]
+        self.ensure_permission_polling(PermissionPromptKind::Accessibility);
     }
 
     #[cfg(target_os = "macos")]
     pub fn on_permission_action(&self) {
-        let prompt = {
-            let mut inner = self.inner.lock().unwrap();
-            match inner.permission_prompt {
-                Some(prompt) if !inner.permission_poll_pending => {
-                    inner.permission_poll_pending = true;
-                    prompt
-                }
-                _ => return,
-            }
+        let prompt = match self.inner.lock().unwrap().permission_prompt {
+            Some(prompt) => prompt,
+            None => return,
         };
 
         match prompt {
@@ -458,27 +457,47 @@ impl Orchestrator {
                     return;
                 }
 
-                let app = self.app_handle();
-                let orch = app.state::<Arc<Orchestrator>>();
-                let orch = Arc::clone(&orch);
-                std::thread::Builder::new()
-                    .name("yap-accessibility-permission-wait".into())
-                    .spawn(move || {
-                        for _ in 0..120 {
-                            if hotkey::has_accessibility_permission() {
-                                orch.finish_permission_granted(prompt);
-                                return;
-                            }
-                            std::thread::sleep(std::time::Duration::from_secs(1));
-                        }
-
-                        let mut inner = orch.inner.lock().unwrap();
-                        inner.permission_poll_pending = false;
-                        inner.emit_permission_prompt();
-                    })
-                    .ok();
+                self.ensure_permission_polling(prompt);
             }
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn ensure_permission_polling(&self, prompt: PermissionPromptKind) {
+        let should_spawn = {
+            let mut inner = self.inner.lock().unwrap();
+            match inner.permission_prompt {
+                Some(current) if current == prompt && !inner.permission_poll_pending => {
+                    inner.permission_poll_pending = true;
+                    true
+                }
+                _ => false,
+            }
+        };
+
+        if !should_spawn {
+            return;
+        }
+
+        let app = self.app_handle();
+        let orch = app.state::<Arc<Orchestrator>>();
+        let orch = Arc::clone(&orch);
+        std::thread::Builder::new()
+            .name("yap-accessibility-permission-wait".into())
+            .spawn(move || {
+                for _ in 0..120 {
+                    if hotkey::has_accessibility_permission() {
+                        orch.finish_permission_granted(prompt);
+                        return;
+                    }
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                }
+
+                let mut inner = orch.inner.lock().unwrap();
+                inner.permission_poll_pending = false;
+                inner.emit_permission_prompt();
+            })
+            .ok();
     }
 
     #[cfg(target_os = "macos")]

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- start the macOS Accessibility permission watcher as soon as Yap shows the permission prompt
- keep the overlay button path, but let manual grants in System Settings clear the prompt automatically
- bump Yap to v2.3.2

## Test plan
- [x] npm run check
- [x] cargo check