### PR TITLE
fix: clarify Accessibility permission recovery

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ This document is the single source of truth for feature parity in the Tauri-base
 | macOS bundle ID | `com.yap.desktop` |
 | Windows app ID | `com.yap.desktop` |
 | Version scheme | SemVer: `MAJOR.MINOR.PATCH` |
-| Current version | `2.3.2` |
+| Current version | `2.3.4` |
 | Activation policy | **Background/accessory** -- no Dock icon (macOS `LSUIElement = true`), no taskbar window (Windows: tray-only) |
 
 ---

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6962,7 +6962,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.3.3"
+version = "2.3.4"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/src/orchestrator.rs
+++ b/tauri-app/src-tauri/src/orchestrator.rs
@@ -354,7 +354,7 @@ impl OrchestratorInner {
                     crate::sidecar::send(&crate::sidecar::OutMessage::Permission {
                         title: "Enable Accessibility".to_string(),
                         message: format!(
-                            "Yap needs Accessibility to listen for {} while other apps are focused.",
+                            "Yap needs Accessibility for {}. If it keeps showing, remove Yap with the minus button, then enable it again.",
                             self.hotkey_label
                         ),
                         action_label: "Open System Settings".to_string(),

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- shorten the macOS Accessibility permission prompt copy
- add the stale permission recovery step users may need after an update
- bump Yap to v2.3.4

## Test plan
- [x] npm run check
- [x] cargo fmt --check
- [x] cargo check
- [x] npm run build
- [x] npm run tauri -- build