### PR TITLE
fix: relaunch after Accessibility grant

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ This document is the single source of truth for feature parity in the Tauri-base
 | macOS bundle ID | `com.yap.desktop` |
 | Windows app ID | `com.yap.desktop` |
 | Version scheme | SemVer: `MAJOR.MINOR.PATCH` |
-| Current version | `2.3.4` |
+| Current version | `2.3.5` |
 | Activation policy | **Background/accessory** -- no Dock icon (macOS `LSUIElement = true`), no taskbar window (Windows: tray-only) |
 
 ---

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6962,7 +6962,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.3.4"
+version = "2.3.5"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/src/orchestrator.rs
+++ b/tauri-app/src-tauri/src/orchestrator.rs
@@ -502,29 +502,29 @@ impl Orchestrator {
 
     #[cfg(target_os = "macos")]
     fn finish_permission_granted(&self, prompt: PermissionPromptKind) {
-        match prompt {
+        let restart_after_grant = match prompt {
             PermissionPromptKind::Accessibility => {
-                log::info("Accessibility granted; restarting hotkey listener");
+                log::info("Accessibility granted; restarting app to refresh event tap trust");
                 hotkey::stop();
-                let cfg = config::get();
-                let spec = parse_hotkey_spec(&cfg.hotkey);
-                let app = self.app_handle();
-                let orch = app.state::<Arc<Orchestrator>>();
-                start_hotkey_listener(Arc::clone(&orch), spec);
+                true
             }
-        }
+        };
 
-        let mut inner = self.inner.lock().unwrap();
-        inner.permission_prompt = None;
-        inner.permission_poll_pending = false;
-        inner.emit_permission_prompt();
-        inner.emit_state();
+        {
+            let mut inner = self.inner.lock().unwrap();
+            inner.permission_prompt = None;
+            inner.permission_poll_pending = false;
+            inner.emit_permission_prompt();
+            inner.emit_state();
 
-        if !inner.onboarding_complete {
-            if inner.onboarding_step.is_none() {
+            if !inner.onboarding_complete && inner.onboarding_step.is_none() {
                 inner.onboarding_step = Some(OnboardingStep::TryIt);
             }
             inner.emit_onboarding();
+        }
+
+        if restart_after_grant {
+            self.app_handle().request_restart();
         }
     }
 

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- relaunch Yap after macOS Accessibility permission becomes trusted
- avoid relying on in-process CGEventTap recovery after TCC changes
- bump Yap to v2.3.5

## Test plan
- [x] npm run check
- [x] cargo fmt --check
- [x] cargo check
- [x] npm run build
- [x] npm run tauri -- build