### PR TITLE
fix: clean up Accessibility prompt

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -49,7 +49,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ This document is the single source of truth for feature parity in the Tauri-base
 | macOS bundle ID | `com.yap.desktop` |
 | Windows app ID | `com.yap.desktop` |
 | Version scheme | SemVer: `MAJOR.MINOR.PATCH` |
-| Current version | `2.3.5` |
+| Current version | `2.3.4` |
 | Activation policy | **Background/accessory** -- no Dock icon (macOS `LSUIElement = true`), no taskbar window (Windows: tray-only) |
 
 ---

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.3.5",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.3.5",
+      "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.3.5",
+  "version": "2.3.4",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6962,7 +6962,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.3.5"
+version = "2.3.4"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.3.5"
+version = "2.3.4"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/sidecar-overlay/Sources/OverlayPanel.swift
+++ b/tauri-app/src-tauri/sidecar-overlay/Sources/OverlayPanel.swift
@@ -897,7 +897,7 @@ struct PermissionCardView: View {
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.white.opacity(0.78))
                 .multilineTextAlignment(.center)
-                .lineLimit(2)
+                .lineLimit(4)
                 .frame(width: 315)
 
             Text(prompt.actionLabel)

--- a/tauri-app/src-tauri/src/orchestrator.rs
+++ b/tauri-app/src-tauri/src/orchestrator.rs
@@ -353,10 +353,7 @@ impl OrchestratorInner {
                 Some(PermissionPromptKind::Accessibility) => {
                     crate::sidecar::send(&crate::sidecar::OutMessage::Permission {
                         title: "Enable Accessibility".to_string(),
-                        message: format!(
-                            "Yap needs Accessibility for {}. If it keeps showing, remove Yap with the minus button, then enable it again.",
-                            self.hotkey_label
-                        ),
+                        message: "Yap needs Accessibility to detect your record shortcut in other apps. If this keeps showing, remove Yap from Accessibility and restart.".to_string(),
                         action_label: "Open System Settings".to_string(),
                         visible: true,
                     });
@@ -502,29 +499,29 @@ impl Orchestrator {
 
     #[cfg(target_os = "macos")]
     fn finish_permission_granted(&self, prompt: PermissionPromptKind) {
-        let restart_after_grant = match prompt {
+        match prompt {
             PermissionPromptKind::Accessibility => {
-                log::info("Accessibility granted; restarting app to refresh event tap trust");
+                log::info("Accessibility granted; restarting hotkey listener");
                 hotkey::stop();
-                true
+                let cfg = config::get();
+                let spec = parse_hotkey_spec(&cfg.hotkey);
+                let app = self.app_handle();
+                let orch = app.state::<Arc<Orchestrator>>();
+                start_hotkey_listener(Arc::clone(&orch), spec);
             }
-        };
+        }
 
-        {
-            let mut inner = self.inner.lock().unwrap();
-            inner.permission_prompt = None;
-            inner.permission_poll_pending = false;
-            inner.emit_permission_prompt();
-            inner.emit_state();
+        let mut inner = self.inner.lock().unwrap();
+        inner.permission_prompt = None;
+        inner.permission_poll_pending = false;
+        inner.emit_permission_prompt();
+        inner.emit_state();
 
-            if !inner.onboarding_complete && inner.onboarding_step.is_none() {
+        if !inner.onboarding_complete {
+            if inner.onboarding_step.is_none() {
                 inner.onboarding_step = Some(OnboardingStep::TryIt);
             }
             inner.emit_onboarding();
-        }
-
-        if restart_after_grant {
-            self.app_handle().request_restart();
         }
     }
 

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.3.5",
+  "version": "2.3.4",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- replace the Accessibility permission message with shorter shortcut-focused copy
- allow the macOS permission prompt message to wrap to four lines
- remove the yanked relaunch-after-grant behavior from main
- bump Yap to v2.3.4

## Test plan
- [x] npm run check
- [x] cargo fmt --check
- [x] cargo check
- [x] npm run build
- [x] npm run tauri -- build