### PR TITLE
Release v2.4.1

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ This document is the single source of truth for feature parity in the Tauri-base
 | macOS bundle ID | `com.yap.desktop` |
 | Windows app ID | `com.yap.desktop` |
 | Version scheme | SemVer: `MAJOR.MINOR.PATCH` |
-| Current version | `2.4.0` |
+| Current version | `2.4.1` |
 | Activation policy | **Background/accessory** -- no Dock icon (macOS `LSUIElement = true`), no taskbar window (Windows: tray-only) |
 
 ---

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6962,7 +6962,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.4.0"
+version = "2.4.1"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/tauri-app/src/lib/settings/Settings.svelte
+++ b/tauri-app/src/lib/settings/Settings.svelte
@@ -62,7 +62,9 @@
 
   // ── Provider Metadata ─────────────────────────────────────────────────
 
-  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isWindows = userAgent.includes('windows');
+  const isMac = userAgent.includes('macintosh') || userAgent.includes('mac os');
   const isTauriRuntime = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
   const defaultHotkey = isWindows ? 'capslock' : 'fn';
   const defaultTxProvider = isWindows ? 'openai' : 'none';
@@ -1072,7 +1074,7 @@
     <span>Loading...</span>
   </div>
 {:else}
-  <div class="settings-container">
+  <div class:platform-macos={isMac} class="settings-container">
     <div
       class="settings-drag-region"
       data-tauri-drag-region

--- a/tauri-app/src/lib/settings/settings.css
+++ b/tauri-app/src/lib/settings/settings.css
@@ -54,6 +54,7 @@ button {
 }
 
 .settings-container {
+  --settings-window-top-padding: 24px;
   display: flex;
   width: 100%;
   height: 100vh;
@@ -64,6 +65,10 @@ button {
   font-size: 13px;
   line-height: 1.4;
   -webkit-font-smoothing: antialiased;
+}
+
+.settings-container.platform-macos {
+  --settings-window-top-padding: 36px;
 }
 
 .loading-state {
@@ -80,7 +85,7 @@ button {
   flex: 0 0 236px;
   flex-direction: column;
   min-width: 0;
-  padding: 24px 12px 14px;
+  padding: var(--settings-window-top-padding) 12px 14px;
   border-right: 1px solid var(--settings-border);
 }
 
@@ -181,7 +186,7 @@ button {
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 24px 32px 32px;
+  padding: var(--settings-window-top-padding) 32px 32px;
 }
 
 .settings-section {


### PR DESCRIPTION
## Summary
- fix: restore macOS Settings top spacing while keeping the Windows 2.4.0 compact layout
- chore: bump version to 2.4.1

## Testing
- [x] `npm run check`
- [x] `cargo check`
- [x] `cargo fmt`
- [x] `npm run build`

## Version Files
- `tauri-app/package.json`
- `tauri-app/package-lock.json`
- `tauri-app/src-tauri/Cargo.toml`
- `tauri-app/src-tauri/Cargo.lock`
- `tauri-app/src-tauri/tauri.conf.json`
- `SPEC.md`

## Release Notes Preview
## What's Changed
* fix: restore macOS Settings top spacing while keeping Windows compact by @oobagi in this PR
* chore: bump version to 2.4.1 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v2.4.0...v2.4.1