### PR TITLE
Release v2.4.1

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ This document is the single source of truth for feature parity in the Tauri-base
 | macOS bundle ID | `com.yap.desktop` |
 | Windows app ID | `com.yap.desktop` |
 | Version scheme | SemVer: `MAJOR.MINOR.PATCH` |
-| Current version | `2.4.0` |
+| Current version | `2.4.1` |
 | Activation policy | **Background/accessory** -- no Dock icon (macOS `LSUIElement = true`), no taskbar window (Windows: tray-only) |
 
 ---

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yap",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yap",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Cross-platform voice-to-text tray app",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6962,7 +6962,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.4.0"
+version = "2.4.1"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["you"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Yap",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "identifier": "com.yap.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/tauri-app/src/lib/settings/Settings.svelte
+++ b/tauri-app/src/lib/settings/Settings.svelte
@@ -62,7 +62,9 @@
 
   // ── Provider Metadata ─────────────────────────────────────────────────
 
-  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isWindows = userAgent.includes('windows');
+  const isMac = userAgent.includes('macintosh') || userAgent.includes('mac os');
   const isTauriRuntime = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
   const defaultHotkey = isWindows ? 'capslock' : 'fn';
   const defaultTxProvider = isWindows ? 'openai' : 'none';
@@ -456,17 +458,6 @@
     }
     if (isTauriRuntime) {
       await invoke('hide_app_window', { label: 'settings' });
-    }
-  }
-
-  async function startWindowDrag(e: MouseEvent) {
-    if (!isTauriRuntime || e.button !== 0) return;
-    e.preventDefault();
-
-    try {
-      await getCurrentWindow().startDragging();
-    } catch (error) {
-      console.error('Failed to start window drag:', error);
     }
   }
 
@@ -1072,51 +1063,47 @@
     <span>Loading...</span>
   </div>
 {:else}
-  <div class="settings-container">
-    <div
-      class="settings-drag-region"
-      data-tauri-drag-region
-      aria-hidden="true"
-      onmousedown={startWindowDrag}
-    ></div>
-    <aside class="settings-sidebar" aria-label="Settings sections">
-      <div class="sidebar-header">
-        <img class="app-icon" src="/favicon.png" alt="" aria-hidden="true" />
-        <div>
-          <div class="sidebar-title">Yap</div>
-          <a
-            class="sidebar-subtitle sidebar-version-link"
-            href={buildUrl}
-            onclick={openBuildLink}
-            target="_blank"
-            rel="noreferrer"
-            title="Open this build on GitHub"
-          >
-            {buildLabel}
-          </a>
+  <div class="settings-container" class:platform-macos={isMac}>
+    <div class="settings-titlebar" data-tauri-drag-region aria-hidden="true"></div>
+    <div class="settings-body">
+      <aside class="settings-sidebar" aria-label="Settings sections">
+        <div class="sidebar-header">
+          <img class="app-icon" src="/favicon.png" alt="" aria-hidden="true" />
+          <div>
+            <div class="sidebar-title">Yap</div>
+            <a
+              class="sidebar-subtitle sidebar-version-link"
+              href={buildUrl}
+              onclick={openBuildLink}
+              target="_blank"
+              rel="noreferrer"
+              title="Open this build on GitHub"
+            >
+              {buildLabel}
+            </a>
+          </div>
         </div>
-      </div>
 
-      <nav class="section-nav">
-        {#each settingsSections as section}
-          <button
-            class="section-nav-item"
-            class:active={activeSection === section.id}
-            type="button"
-            aria-current={activeSection === section.id ? 'page' : undefined}
-            aria-controls={'settings-panel-' + section.id}
-            onclick={() => selectSection(section.id)}
-          >
-            <span class="section-nav-label">{section.label}</span>
-            <span class="section-nav-description">{section.description}</span>
-          </button>
-        {/each}
-      </nav>
+        <nav class="section-nav">
+          {#each settingsSections as section}
+            <button
+              class="section-nav-item"
+              class:active={activeSection === section.id}
+              type="button"
+              aria-current={activeSection === section.id ? 'page' : undefined}
+              aria-controls={'settings-panel-' + section.id}
+              onclick={() => selectSection(section.id)}
+            >
+              <span class="section-nav-label">{section.label}</span>
+              <span class="section-nav-description">{section.description}</span>
+            </button>
+          {/each}
+        </nav>
 
-    </aside>
+      </aside>
 
-    <div class="settings-main">
-      <main class="settings-content" id={'settings-panel-' + activeSection}>
+      <div class="settings-main">
+        <main class="settings-content" id={'settings-panel-' + activeSection}>
         {#if activeSection === 'general'}
           <section class="settings-section" aria-label="General settings">
             <div class="section-body">
@@ -1681,7 +1668,8 @@
             </div>
           </section>
         {/if}
-      </main>
+        </main>
+      </div>
     </div>
   </div>
 {/if}

--- a/tauri-app/src/lib/settings/settings.css
+++ b/tauri-app/src/lib/settings/settings.css
@@ -42,19 +42,11 @@ button {
   -webkit-app-region: no-drag;
 }
 
-.settings-drag-region {
-  position: fixed;
-  z-index: 10;
-  top: 0;
-  right: 0;
-  left: 0;
-  height: 42px;
-  app-region: drag;
-  -webkit-app-region: drag;
-}
-
 .settings-container {
+  --settings-titlebar-height: 24px;
+  --settings-window-top-padding: 24px;
   display: flex;
+  position: relative;
   width: 100%;
   height: 100vh;
   overflow: hidden;
@@ -64,6 +56,28 @@ button {
   font-size: 13px;
   line-height: 1.4;
   -webkit-font-smoothing: antialiased;
+}
+
+.settings-container.platform-macos {
+  --settings-window-top-padding: 36px;
+}
+
+.settings-titlebar {
+  position: absolute;
+  z-index: 10;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: var(--settings-titlebar-height);
+  app-region: drag;
+  -webkit-app-region: drag;
+}
+
+.settings-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
 }
 
 .loading-state {
@@ -80,7 +94,7 @@ button {
   flex: 0 0 236px;
   flex-direction: column;
   min-width: 0;
-  padding: 24px 12px 14px;
+  padding: var(--settings-window-top-padding) 12px 14px;
   border-right: 1px solid var(--settings-border);
 }
 
@@ -181,7 +195,7 @@ button {
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 24px 32px 32px;
+  padding: var(--settings-window-top-padding) 32px 32px;
 }
 
 .settings-section {


### PR DESCRIPTION
## Summary
- fix: restore the transparent Settings titlebar drag area without blocking settings controls
- fix: keep the macOS Settings top spacing while preserving the full-height sidebar divider
- chore: bump version to 2.4.1

## Testing
- [x] `npm run check`
- [x] `cargo check`
- [x] `cargo fmt`
- [x] `npm run build`

## Version Files
- `tauri-app/package.json`
- `tauri-app/package-lock.json`
- `tauri-app/src-tauri/Cargo.toml`
- `tauri-app/src-tauri/Cargo.lock`
- `tauri-app/src-tauri/tauri.conf.json`
- `SPEC.md`

## Release Notes Preview
## What's Changed
* fix: restore the transparent Settings titlebar drag area without blocking settings controls by @oobagi in this PR
* fix: keep macOS Settings top spacing while preserving the full-height sidebar divider by @oobagi in this PR
* chore: bump version to 2.4.1 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v2.4.0...v2.4.1