### PR TITLE
Release v3.0.0

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ This document is the single source of truth for feature parity in the Electron-b
 | macOS bundle ID | `com.yap.desktop` |
 | Windows app ID | `com.yap.desktop` |
 | Version scheme | SemVer: `MAJOR.MINOR.PATCH` |
-| Current version | `2.4.1` |
+| Current version | `3.0.0` |
 | Activation policy | **Background/accessory** -- no Dock icon (macOS `LSUIElement = true`), no taskbar window (Windows: tray-only) |
 
 ---

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "2.4.1"
+version = "3.0.0"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "2.4.1"
+version = "3.0.0"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",


### PR DESCRIPTION
## Summary
- feat: ship the Electron desktop migration from PR #61
- feat: publish Electron macOS and Windows artifacts through the new build workflow
- fix: include cross-platform Electron CI fixes from the migration branch
- chore: bump version to 3.0.0

## Testing
- [x] `pnpm run check`
- [x] `pnpm run electron:check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`
- [x] PR #61 Electron Build passed on macOS and Windows
- [x] Manual packaged-app smoke by @oobagi before release

## Version Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`
- `SPEC.md`

## Release Notes Preview
## What's Changed
* feat: migrate the desktop app from Tauri to Electron by @oobagi in https://github.com/oobagi/yap/pull/61
* feat: publish Electron macOS and Windows artifacts through the new build workflow by @oobagi in https://github.com/oobagi/yap/pull/61
* fix: restore Electron dictation, settings, overlay, updater, and background audio parity by @oobagi in https://github.com/oobagi/yap/pull/61
* chore: bump version to 3.0.0 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v2.4.1...v3.0.0
