### PR TITLE
Release v3.0.1

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -79,8 +79,7 @@ jobs:
         working-directory: desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm run electron:package -- --publish never
+        run: pnpm run electron:package:ci
 
       - name: Upload Electron artifacts
         uses: actions/upload-artifact@v4

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ This document is the single source of truth for feature parity in the Electron-b
 | macOS bundle ID | `com.yap.desktop` |
 | Windows app ID | `com.yap.desktop` |
 | Version scheme | SemVer: `MAJOR.MINOR.PATCH` |
-| Current version | `3.0.0` |
+| Current version | `3.0.1` |
 | Activation policy | **Background/accessory** -- no Dock icon (macOS `LSUIElement = true`), no taskbar window (Windows: tray-only) |
 
 ---

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.0"
+version = "3.0.1"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",
@@ -18,6 +18,7 @@
     "electron:build-core": "cargo build --manifest-path native-core/Cargo.toml --release --bin yap-core",
     "electron:build-sidecar": "node scripts/build-sidecar.mjs",
     "electron:package": "pnpm run electron:build && pnpm run electron:build-core && pnpm run electron:build-sidecar && electron-builder --config electron-builder.yml",
+    "electron:package:ci": "pnpm run electron:build && pnpm run electron:build-core && pnpm run electron:build-sidecar && electron-builder --config electron-builder.yml --publish never",
     "electron:check": "tsc --noEmit --project tsconfig.electron.json"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
- fix: prevent `electron-builder` from creating a GitHub Release during the build matrix
- fix: keep artifact publishing in the dedicated release job
- chore: bump version to 3.0.1

## Context
- `v3.0.0` was tagged, but its tag workflow failed because the macOS build job tried to create a GitHub Release directly with a read-scoped token.
- This patch avoids deleting or reusing that tag and publishes the Electron migration as `v3.0.1`.

## Testing
- [x] `pnpm run check`
- [x] `pnpm run electron:check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:package:ci`

## Version Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`
- `SPEC.md`

## Release Notes Preview
## What's Changed
* feat: migrate the desktop app from Tauri to Electron by @oobagi in https://github.com/oobagi/yap/pull/61
* feat: publish Electron macOS and Windows artifacts through the new build workflow by @oobagi in https://github.com/oobagi/yap/pull/61
* fix: restore Electron dictation, settings, overlay, updater, and background audio parity by @oobagi in https://github.com/oobagi/yap/pull/61
* fix: prevent Electron builder from publishing inside the build matrix by @oobagi in this PR
* chore: bump version to 3.0.1 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v2.4.1...v3.0.1
