### PR TITLE
Release v3.0.2

### DIFF
--- a/desktop/electron/main/index.ts
+++ b/desktop/electron/main/index.ts
@@ -7,6 +7,10 @@ import { YapCoreSidecar } from "./sidecar";
 import { installTray, refreshHistoryMenu } from "./tray";
 import { createMainWindow, hideAppIfNoWindowsVisible, sendToAllWindows, sendToWindow, showAppWindow } from "./windows";
 
+if (process.platform === "darwin") {
+  app.commandLine.appendSwitch("use-mock-keychain");
+}
+
 const sidecar = new YapCoreSidecar({
   appRoot,
   onEvent: handleSidecarEvent,

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.1"
+version = "3.0.2"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",


### PR DESCRIPTION
## Summary
- fix: suppress the macOS Keychain Safe Storage prompt for users
- docs: update Electron documentation
- chore: remove legacy Yap migration traces
- chore: bump version to 3.0.2

## Testing
- [x] `pnpm run check`
- [x] `pnpm run electron:check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`

## Version Bump Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* docs: update Electron documentation by @oobagi in https://github.com/oobagi/yap/commit/833eb40
* chore: remove legacy Yap migration traces by @oobagi in https://github.com/oobagi/yap/commit/ecb0c36
* fix: suppress macOS Keychain storage prompt by @oobagi in this PR
* chore: bump version to 3.0.2 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.1...v3.0.2

Note: the docs and migration cleanup commits were already on `main`, so their release-note preview uses commit links instead of PR links.