### PR TITLE
Release v3.0.3

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -82,7 +82,7 @@ jobs:
         run: pnpm run electron:package:ci
 
       - name: Verify macOS entitlements
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')
         working-directory: desktop
         run: pnpm run electron:verify-mac-entitlements
 

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -81,6 +81,11 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
         run: pnpm run electron:package:ci
 
+      - name: Verify macOS entitlements
+        if: runner.os == 'macOS'
+        working-directory: desktop
+        run: pnpm run electron:verify-mac-entitlements
+
       - name: Upload Electron artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -27,6 +27,8 @@ extraResources:
 mac:
   category: public.app-category.productivity
   icon: native-core/icons/icon.icns
+  entitlements: electron/entitlements.mac.plist
+  entitlementsInherit: electron/entitlements.mac.inherit.plist
   extendInfo:
     NSMicrophoneUsageDescription: Yap records your voice so it can transcribe and paste what you say.
     NSSpeechRecognitionUsageDescription: Yap uses speech recognition to transcribe audio locally when available.

--- a/desktop/electron/entitlements.mac.inherit.plist
+++ b/desktop/electron/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/desktop/electron/entitlements.mac.plist
+++ b/desktop/electron/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/desktop/electron/main/config.ts
+++ b/desktop/electron/main/config.ts
@@ -35,10 +35,6 @@ export interface AppConfig {
   speechLocale: string;
 }
 
-type PersistedAppConfig = Partial<AppConfig> & {
-  quietAudioWhileRecording?: unknown;
-};
-
 let cachedConfig: AppConfig = defaultConfig();
 
 export function configDir(): string {
@@ -106,11 +102,9 @@ function defaultConfig(): AppConfig {
   };
 }
 
-function normalizeConfig(input: PersistedAppConfig | null | undefined): AppConfig {
+function normalizeConfig(input: Partial<AppConfig> | null | undefined): AppConfig {
   const defaults = defaultConfig();
-  const persisted = input ?? {};
   const config = { ...defaults, ...(input ?? {}) };
-  const backgroundAudioMode = resolveBackgroundAudioMode(persisted, defaults.backgroundAudioMode);
 
   return {
     ...config,
@@ -126,7 +120,9 @@ function normalizeConfig(input: PersistedAppConfig | null | undefined): AppConfi
     oaiPrompt: stringOrDefault(config.oaiPrompt, ""),
     elLanguageCode: stringOrDefault(config.elLanguageCode, ""),
     speechLocale: stringOrDefault(config.speechLocale, ""),
-    backgroundAudioMode,
+    backgroundAudioMode: isBackgroundAudioMode(config.backgroundAudioMode)
+      ? config.backgroundAudioMode
+      : defaults.backgroundAudioMode,
   };
 }
 
@@ -136,19 +132,4 @@ function stringOrDefault(value: unknown, fallback: string): string {
 
 function isBackgroundAudioMode(value: unknown): value is BackgroundAudioMode {
   return value === "off" || value === "mute" || value === "pause";
-}
-
-function resolveBackgroundAudioMode(
-  input: PersistedAppConfig,
-  fallback: BackgroundAudioMode
-): BackgroundAudioMode {
-  if (isBackgroundAudioMode(input.backgroundAudioMode)) {
-    return input.backgroundAudioMode;
-  }
-
-  if (typeof input.quietAudioWhileRecording === "boolean") {
-    return input.quietAudioWhileRecording ? "mute" : "off";
-  }
-
-  return fallback;
 }

--- a/desktop/electron/main/config.ts
+++ b/desktop/electron/main/config.ts
@@ -35,6 +35,10 @@ export interface AppConfig {
   speechLocale: string;
 }
 
+type PersistedAppConfig = Partial<AppConfig> & {
+  quietAudioWhileRecording?: unknown;
+};
+
 let cachedConfig: AppConfig = defaultConfig();
 
 export function configDir(): string {
@@ -102,9 +106,11 @@ function defaultConfig(): AppConfig {
   };
 }
 
-function normalizeConfig(input: Partial<AppConfig> | null | undefined): AppConfig {
+function normalizeConfig(input: PersistedAppConfig | null | undefined): AppConfig {
   const defaults = defaultConfig();
+  const persisted = input ?? {};
   const config = { ...defaults, ...(input ?? {}) };
+  const backgroundAudioMode = resolveBackgroundAudioMode(persisted, defaults.backgroundAudioMode);
 
   return {
     ...config,
@@ -120,9 +126,7 @@ function normalizeConfig(input: Partial<AppConfig> | null | undefined): AppConfi
     oaiPrompt: stringOrDefault(config.oaiPrompt, ""),
     elLanguageCode: stringOrDefault(config.elLanguageCode, ""),
     speechLocale: stringOrDefault(config.speechLocale, ""),
-    backgroundAudioMode: isBackgroundAudioMode(config.backgroundAudioMode)
-      ? config.backgroundAudioMode
-      : defaults.backgroundAudioMode,
+    backgroundAudioMode,
   };
 }
 
@@ -132,4 +136,19 @@ function stringOrDefault(value: unknown, fallback: string): string {
 
 function isBackgroundAudioMode(value: unknown): value is BackgroundAudioMode {
   return value === "off" || value === "mute" || value === "pause";
+}
+
+function resolveBackgroundAudioMode(
+  input: PersistedAppConfig,
+  fallback: BackgroundAudioMode
+): BackgroundAudioMode {
+  if (isBackgroundAudioMode(input.backgroundAudioMode)) {
+    return input.backgroundAudioMode;
+  }
+
+  if (typeof input.quietAudioWhileRecording === "boolean") {
+    return input.quietAudioWhileRecording ? "mute" : "off";
+  }
+
+  return fallback;
 }

--- a/desktop/electron/main/hotkeyCapture.ts
+++ b/desktop/electron/main/hotkeyCapture.ts
@@ -3,26 +3,39 @@ import { sendToWindow } from "./windows";
 
 let captureContents: WebContents | null = null;
 let captureHandler: ((event: Electron.Event, input: Input) => void) | null = null;
+let pressedParts = new Set<string>();
+let lastShortcut = "";
 
 export function startHotkeyCapture(webContents: WebContents): void {
   cancelHotkeyCapture();
   captureContents = webContents;
+  pressedParts = new Set();
+  lastShortcut = "";
   captureHandler = (event, input) => {
-    if (input.type !== "keyDown") return;
-
-    const shortcut = shortcutFromInput(input);
-    if (!shortcut) return;
+    if (input.type !== "keyDown" && input.type !== "keyUp") return;
 
     event.preventDefault();
-    sendToWindow("settings", "settings:hotkey-preview", shortcut);
 
-    if (shortcut === "escape") {
+    const key = normalizeKey(input.key);
+    if (input.type === "keyDown" && key === "escape") {
       cancelHotkeyCapture();
       return;
     }
 
-    sendToWindow("settings", "settings:hotkey-captured", shortcut);
-    cancelHotkeyCapture();
+    updatePressedParts(input, key);
+
+    if (input.type === "keyDown") {
+      const shortcut = shortcutFromPressedParts();
+      if (!shortcut) return;
+      lastShortcut = shortcut;
+      sendToWindow("settings", "settings:hotkey-preview", shortcut);
+      return;
+    }
+
+    if (pressedParts.size === 0 && lastShortcut) {
+      sendToWindow("settings", "settings:hotkey-captured", lastShortcut);
+      cancelHotkeyCapture();
+    }
   };
 
   captureContents.on("before-input-event", captureHandler);
@@ -34,19 +47,38 @@ export function cancelHotkeyCapture(): void {
   }
   captureContents = null;
   captureHandler = null;
+  pressedParts = new Set();
+  lastShortcut = "";
 }
 
-function shortcutFromInput(input: Input): string {
-  const parts: string[] = [];
-  if (input.control) parts.push("ctrl");
-  if (input.meta) parts.push("cmd");
-  if (input.alt) parts.push("option");
-  if (input.shift) parts.push("shift");
+function updatePressedParts(input: Input, key: string): void {
+  syncModifier("cmd", input.meta);
+  syncModifier("ctrl", input.control);
+  syncModifier("option", input.alt);
+  syncModifier("shift", input.shift);
 
-  const key = normalizeKey(input.key);
-  if (key && !parts.includes(key)) parts.push(key);
+  if (!key) return;
 
-  return parts.join("+");
+  if (input.type === "keyDown") {
+    pressedParts.add(key);
+  } else {
+    pressedParts.delete(key);
+  }
+}
+
+function syncModifier(part: string, pressed: boolean): void {
+  if (pressed) {
+    pressedParts.add(part);
+  } else {
+    pressedParts.delete(part);
+  }
+}
+
+function shortcutFromPressedParts(): string {
+  const modifierOrder = ["cmd", "ctrl", "option", "shift"];
+  const modifiers = modifierOrder.filter((modifier) => pressedParts.has(modifier));
+  const triggers = [...pressedParts].filter((part) => !modifierOrder.includes(part));
+  return [...modifiers, ...triggers].join("+");
 }
 
 function normalizeKey(key: string): string {

--- a/desktop/electron/main/index.ts
+++ b/desktop/electron/main/index.ts
@@ -3,6 +3,8 @@ import { configureAppIdentity } from "./appIdentity";
 import { loadConfig } from "./config";
 import { installIpcHandlers } from "./ipc";
 import { appRoot } from "./paths";
+import { isAccessibilityPayload, PermissionSupervisor } from "./permissions";
+import { relaunchApp } from "./relaunch";
 import { YapCoreSidecar } from "./sidecar";
 import { installTray, refreshHistoryMenu } from "./tray";
 import { createMainWindow, hideAppIfNoWindowsVisible, sendToAllWindows, sendToWindow, showAppWindow } from "./windows";
@@ -15,12 +17,16 @@ const sidecar = new YapCoreSidecar({
   appRoot,
   onEvent: handleSidecarEvent,
 });
+const permissions = new PermissionSupervisor({
+  onAccessibilityGranted: () => relaunchApp(() => sidecar.stop()),
+});
 
 app.whenReady().then(async () => {
   configureAppIdentity();
   Menu.setApplicationMenu(null);
   installIpcHandlers(sidecar);
   await loadConfig();
+  await permissions.preflight();
   await installTray({
     setEnabled: async (enabled) => {
       await sidecar.invoke(enabled ? "runtime.start" : "runtime.stop", {});
@@ -42,6 +48,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  permissions.stop();
   void sidecar.stop();
 });
 
@@ -63,6 +70,10 @@ async function handleSidecarEvent({
     await showAppWindow("settings");
     sendToWindow("settings", event, payload);
     return;
+  }
+
+  if (event === "dictation:permission-required" && isAccessibilityPayload(payload)) {
+    permissions.ensureAccessibility("runtime");
   }
 
   if (target === "main" || target === "settings") {

--- a/desktop/electron/main/ipc.ts
+++ b/desktop/electron/main/ipc.ts
@@ -1,6 +1,7 @@
 import { app, dialog, ipcMain, shell, type WebContents } from "electron";
 import { loadConfig } from "./config";
 import { cancelHotkeyCapture, startHotkeyCapture } from "./hotkeyCapture";
+import { relaunchApp } from "./relaunch";
 import type { YapCoreSidecar } from "./sidecar";
 import { refreshHistoryMenu } from "./tray";
 import {
@@ -34,13 +35,14 @@ async function dispatchInvoke(
   sender: WebContents
 ): Promise<unknown> {
   if (isElectronLocalCommand(command)) {
-    return dispatchElectronLocal(command, args, sender);
+    return dispatchElectronLocal(sidecar, command, args, sender);
   }
 
   return sidecar.invoke(command, args);
 }
 
 async function dispatchElectronLocal(
+  sidecar: YapCoreSidecar,
   command: string,
   args: InvokeArgs,
   sender: WebContents
@@ -88,8 +90,7 @@ async function dispatchElectronLocal(
     case "updater.download_and_install":
       return downloadAndInstallElectronUpdate(sender);
     case "app.relaunch":
-      app.relaunch();
-      app.exit(0);
+      await relaunchApp(() => sidecar.stop());
       return null;
     default:
       throw new Error(`Electron backend command is not implemented: ${command}`);

--- a/desktop/electron/main/ipc.ts
+++ b/desktop/electron/main/ipc.ts
@@ -1,7 +1,6 @@
 import { app, dialog, ipcMain, shell, type WebContents } from "electron";
 import { loadConfig } from "./config";
 import { cancelHotkeyCapture, startHotkeyCapture } from "./hotkeyCapture";
-import { relaunchApp } from "./relaunch";
 import type { YapCoreSidecar } from "./sidecar";
 import { refreshHistoryMenu } from "./tray";
 import {
@@ -89,9 +88,6 @@ async function dispatchElectronLocal(
       return checkForElectronUpdate();
     case "updater.download_and_install":
       return downloadAndInstallElectronUpdate(sender);
-    case "app.relaunch":
-      await relaunchApp(() => sidecar.stop());
-      return null;
     default:
       throw new Error(`Electron backend command is not implemented: ${command}`);
   }
@@ -113,8 +109,7 @@ function isElectronLocalCommand(command: string): boolean {
     command === "autostart.enable" ||
     command === "autostart.disable" ||
     command === "updater.check" ||
-    command === "updater.download_and_install" ||
-    command === "app.relaunch"
+    command === "updater.download_and_install"
   );
 }
 

--- a/desktop/electron/main/permissions.ts
+++ b/desktop/electron/main/permissions.ts
@@ -1,0 +1,120 @@
+import { shell, systemPreferences } from "electron";
+
+type AccessibilityPromptReason = "startup" | "runtime" | "user-action";
+
+interface PermissionSupervisorOptions {
+  onAccessibilityGranted: () => Promise<void> | void;
+}
+
+const ACCESSIBILITY_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+const MICROPHONE_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
+const ACCESSIBILITY_POLL_INTERVAL_MS = 1_000;
+
+export class PermissionSupervisor {
+  private accessibilityPoll: NodeJS.Timeout | null = null;
+  private accessibilityPromptShown = false;
+  private accessibilitySettingsOpened = false;
+  private accessibilityGrantInFlight = false;
+
+  constructor(private readonly options: PermissionSupervisorOptions) {}
+
+  async preflight(): Promise<void> {
+    if (process.platform !== "darwin") return;
+
+    try {
+      await requestMicrophoneAccess();
+    } catch (error) {
+      console.warn("[yap] microphone permission preflight failed:", error);
+    }
+
+    try {
+      this.ensureAccessibility("startup");
+    } catch (error) {
+      console.warn("[yap] Accessibility permission preflight failed:", error);
+    }
+  }
+
+  ensureAccessibility(reason: AccessibilityPromptReason): void {
+    if (process.platform !== "darwin") return;
+
+    if (systemPreferences.isTrustedAccessibilityClient(false)) {
+      this.stopAccessibilityPolling();
+      return;
+    }
+
+    console.warn(`[yap] Accessibility permission required (${reason})`);
+
+    if (!this.accessibilityPromptShown) {
+      this.accessibilityPromptShown = true;
+      const trustedAfterPrompt = systemPreferences.isTrustedAccessibilityClient(true);
+      console.warn(`[yap] Accessibility prompt returned trusted=${trustedAfterPrompt}`);
+      if (trustedAfterPrompt) return;
+    }
+
+    if (!this.accessibilitySettingsOpened) {
+      this.accessibilitySettingsOpened = true;
+      void shell.openExternal(ACCESSIBILITY_SETTINGS_URL).catch((error) => {
+        console.warn("[yap] failed to open Accessibility settings:", error);
+      });
+    }
+
+    this.startAccessibilityPolling();
+  }
+
+  stop(): void {
+    this.stopAccessibilityPolling();
+  }
+
+  private startAccessibilityPolling(): void {
+    if (this.accessibilityPoll) return;
+
+    console.warn("[yap] waiting for Accessibility grant");
+    this.accessibilityPoll = setInterval(() => {
+      if (!systemPreferences.isTrustedAccessibilityClient(false)) return;
+      if (this.accessibilityGrantInFlight) return;
+
+      this.accessibilityGrantInFlight = true;
+      console.warn("[yap] Accessibility grant detected; relaunching");
+      this.stopAccessibilityPolling();
+      Promise.resolve(this.options.onAccessibilityGranted()).catch((error) => {
+        console.warn("[yap] failed to relaunch after Accessibility grant:", error);
+        this.accessibilityGrantInFlight = false;
+      });
+    }, ACCESSIBILITY_POLL_INTERVAL_MS);
+    this.accessibilityPoll.unref();
+  }
+
+  private stopAccessibilityPolling(): void {
+    if (!this.accessibilityPoll) return;
+    clearInterval(this.accessibilityPoll);
+    this.accessibilityPoll = null;
+    this.accessibilityGrantInFlight = false;
+  }
+}
+
+export function isAccessibilityPayload(payload: unknown): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "permission" in payload &&
+    (payload as { permission?: unknown }).permission === "accessibility"
+  );
+}
+
+async function requestMicrophoneAccess(): Promise<void> {
+  const status = systemPreferences.getMediaAccessStatus("microphone");
+  console.info(`[yap] microphone permission status=${status}`);
+
+  if (status === "not-determined") {
+    const granted = await systemPreferences.askForMediaAccess("microphone");
+    console.info(`[yap] microphone permission prompt granted=${granted}`);
+    return;
+  }
+
+  if (status === "denied" || status === "restricted") {
+    console.warn(`[yap] microphone permission is ${status}; opening Microphone settings`);
+    await shell.openExternal(MICROPHONE_SETTINGS_URL);
+  }
+}

--- a/desktop/electron/main/relaunch.ts
+++ b/desktop/electron/main/relaunch.ts
@@ -1,0 +1,17 @@
+import { app } from "electron";
+import { allowWindowCloseForQuit } from "./windows";
+
+export async function relaunchApp(beforeExit?: () => Promise<void> | void): Promise<void> {
+  allowWindowCloseForQuit();
+
+  if (beforeExit) {
+    try {
+      await beforeExit();
+    } catch (error) {
+      console.warn("[yap] continuing relaunch after cleanup failed:", error);
+    }
+  }
+
+  app.relaunch();
+  app.exit(0);
+}

--- a/desktop/electron/main/updater.ts
+++ b/desktop/electron/main/updater.ts
@@ -1,5 +1,6 @@
 import { app, type WebContents } from "electron";
 import electronUpdater from "electron-updater";
+import { allowWindowCloseForQuit } from "./windows";
 
 const { autoUpdater } = electronUpdater;
 
@@ -20,6 +21,7 @@ export async function downloadAndInstallElectronUpdate(sender: WebContents): Pro
   if (!app.isPackaged) return null;
 
   let transferred = 0;
+  console.info("[yap-updater] starting update download");
   sender.send("yap:updater-download", {
     event: "Started",
     data: {},
@@ -45,15 +47,29 @@ export async function downloadAndInstallElectronUpdate(sender: WebContents): Pro
     };
     const onDownloaded = () => {
       cleanup();
+      console.info("[yap-updater] update download completed");
       sender.send("yap:updater-download", {
         event: "Finished",
         data: {},
       });
-      autoUpdater.quitAndInstall(false, true);
+      allowWindowCloseForQuit();
+      try {
+        console.info("[yap-updater] calling quitAndInstall");
+        autoUpdater.quitAndInstall(false, true);
+      } catch (error) {
+        console.error("[yap-updater] quitAndInstall failed:", error);
+        reject(error);
+        return;
+      }
+      setTimeout(() => {
+        console.warn("[yap-updater] quitAndInstall did not exit promptly; falling back to app.quit");
+        app.quit();
+      }, 5000).unref();
       resolve(null);
     };
     const onError = (error: Error) => {
       cleanup();
+      console.error("[yap-updater] update install failed:", error);
       reject(error);
     };
 

--- a/desktop/electron/main/windows.ts
+++ b/desktop/electron/main/windows.ts
@@ -11,6 +11,10 @@ app.on("before-quit", () => {
   isQuitting = true;
 });
 
+export function allowWindowCloseForQuit(): void {
+  isQuitting = true;
+}
+
 export function getWindow(label: WindowLabel): BrowserWindow | null {
   const window = windows.get(label);
   return window && !window.isDestroyed() ? window : null;

--- a/desktop/electron/preload/index.ts
+++ b/desktop/electron/preload/index.ts
@@ -75,7 +75,6 @@ const bridge: YapBridge = {
   },
   app: {
     getInfo: () => ipcRenderer.invoke("yap:app-info") as Promise<YapInfo>,
-    relaunch: () => invoke("app.relaunch"),
   },
   windows: {
     openSettings: () => invoke("window.open_settings"),

--- a/desktop/electron/preload/types.ts
+++ b/desktop/electron/preload/types.ts
@@ -35,7 +35,6 @@ export interface YapBridge {
   };
   app: {
     getInfo(): Promise<YapInfo>;
-    relaunch(): Promise<void>;
   };
   windows: {
     openSettings(): Promise<void>;

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.2"
+version = "3.0.3"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/native-core/src/config.rs
+++ b/desktop/native-core/src/config.rs
@@ -225,10 +225,7 @@ pub fn load() -> Result<AppConfig, String> {
 
     let config = if path.exists() {
         let data = fs::read_to_string(&path).map_err(|e| format!("failed to read config: {e}"))?;
-        serde_json::from_str::<AppConfig>(&data).unwrap_or_else(|_| {
-            // File exists but is malformed -- fall back to defaults.
-            AppConfig::default()
-        })
+        parse_config_json(&data).unwrap_or_else(|_| AppConfig::default())
     } else {
         let config = AppConfig::default();
         // Write defaults so the file exists for the user to inspect.
@@ -270,10 +267,58 @@ pub fn update<F: FnOnce(&mut AppConfig)>(f: F) -> Result<AppConfig, String> {
 
 // ---- Internal -------------------------------------------------------------
 
+fn parse_config_json(data: &str) -> Result<AppConfig, serde_json::Error> {
+    let mut value = serde_json::from_str::<serde_json::Value>(data)?;
+    normalize_legacy_config_value(&mut value);
+    serde_json::from_value::<AppConfig>(value)
+}
+
+fn normalize_legacy_config_value(value: &mut serde_json::Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    if object.contains_key("backgroundAudioMode") {
+        return;
+    }
+
+    if let Some(quiet) = object
+        .get("quietAudioWhileRecording")
+        .and_then(serde_json::Value::as_bool)
+    {
+        object.insert(
+            "backgroundAudioMode".to_string(),
+            serde_json::Value::String(if quiet { "mute" } else { "off" }.to_string()),
+        );
+    }
+}
+
 fn save_to_disk(config: &AppConfig) -> Result<(), String> {
     let path = config_path()?;
     let json = serde_json::to_string_pretty(config)
         .map_err(|e| format!("failed to serialize config: {e}"))?;
     fs::write(&path, json).map_err(|e| format!("failed to write config: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_quiet_audio_false_maps_to_background_audio_off() {
+        let config = parse_config_json(r#"{"quietAudioWhileRecording":false}"#).unwrap();
+
+        assert_eq!(config.background_audio_mode, BackgroundAudioMode::Off);
+    }
+
+    #[test]
+    fn explicit_background_audio_mode_wins_over_legacy_quiet_audio() {
+        let config = parse_config_json(
+            r#"{"quietAudioWhileRecording":false,"backgroundAudioMode":"pause"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.background_audio_mode, BackgroundAudioMode::Pause);
+    }
 }

--- a/desktop/native-core/src/config.rs
+++ b/desktop/native-core/src/config.rs
@@ -225,7 +225,7 @@ pub fn load() -> Result<AppConfig, String> {
 
     let config = if path.exists() {
         let data = fs::read_to_string(&path).map_err(|e| format!("failed to read config: {e}"))?;
-        parse_config_json(&data).unwrap_or_else(|_| AppConfig::default())
+        serde_json::from_str(&data).unwrap_or_else(|_| AppConfig::default())
     } else {
         let config = AppConfig::default();
         // Write defaults so the file exists for the user to inspect.
@@ -267,58 +267,10 @@ pub fn update<F: FnOnce(&mut AppConfig)>(f: F) -> Result<AppConfig, String> {
 
 // ---- Internal -------------------------------------------------------------
 
-fn parse_config_json(data: &str) -> Result<AppConfig, serde_json::Error> {
-    let mut value = serde_json::from_str::<serde_json::Value>(data)?;
-    normalize_legacy_config_value(&mut value);
-    serde_json::from_value::<AppConfig>(value)
-}
-
-fn normalize_legacy_config_value(value: &mut serde_json::Value) {
-    let Some(object) = value.as_object_mut() else {
-        return;
-    };
-
-    if object.contains_key("backgroundAudioMode") {
-        return;
-    }
-
-    if let Some(quiet) = object
-        .get("quietAudioWhileRecording")
-        .and_then(serde_json::Value::as_bool)
-    {
-        object.insert(
-            "backgroundAudioMode".to_string(),
-            serde_json::Value::String(if quiet { "mute" } else { "off" }.to_string()),
-        );
-    }
-}
-
 fn save_to_disk(config: &AppConfig) -> Result<(), String> {
     let path = config_path()?;
     let json = serde_json::to_string_pretty(config)
         .map_err(|e| format!("failed to serialize config: {e}"))?;
     fs::write(&path, json).map_err(|e| format!("failed to write config: {e}"))?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn legacy_quiet_audio_false_maps_to_background_audio_off() {
-        let config = parse_config_json(r#"{"quietAudioWhileRecording":false}"#).unwrap();
-
-        assert_eq!(config.background_audio_mode, BackgroundAudioMode::Off);
-    }
-
-    #[test]
-    fn explicit_background_audio_mode_wins_over_legacy_quiet_audio() {
-        let config = parse_config_json(
-            r#"{"quietAudioWhileRecording":false,"backgroundAudioMode":"pause"}"#,
-        )
-        .unwrap();
-
-        assert_eq!(config.background_audio_mode, BackgroundAudioMode::Pause);
-    }
 }

--- a/desktop/native-core/src/dictation.rs
+++ b/desktop/native-core/src/dictation.rs
@@ -81,8 +81,6 @@ static HOST: once_cell::sync::Lazy<Mutex<Option<Arc<dyn DictationHost>>>> =
     once_cell::sync::Lazy::new(|| Mutex::new(None));
 static LEVEL_POLLER_STARTED: AtomicBool = AtomicBool::new(false);
 static RUNNING: AtomicBool = AtomicBool::new(false);
-#[cfg(target_os = "macos")]
-static ACCESSIBILITY_PERMISSION_POLLING: AtomicBool = AtomicBool::new(false);
 
 pub fn start(host: Arc<dyn DictationHost>) -> Result<(), String> {
     let _ = config::load();
@@ -113,6 +111,10 @@ pub fn start(host: Arc<dyn DictationHost>) -> Result<(), String> {
 }
 
 fn on_accessibility_permission_required(label: String) {
+    emit_accessibility_permission_required(&label);
+}
+
+fn emit_accessibility_permission_required(label: &str) {
     emit_overlay_permission(
         "Accessibility Required",
         &format!("Allow Accessibility access to use the {label} hotkey anywhere."),
@@ -126,9 +128,6 @@ fn on_accessibility_permission_required(label: String) {
             "hotkeyLabel": label,
         }),
     );
-
-    #[cfg(target_os = "macos")]
-    ensure_accessibility_permission_polling();
 }
 
 #[cfg(target_os = "macos")]
@@ -145,69 +144,9 @@ fn clear_permission_prompt_if_available() {
 
 #[cfg(target_os = "macos")]
 fn on_accessibility_permission_action() {
-    emit(
-        "dictation:permission-requested",
-        json!({ "permission": "accessibility" }),
-    );
-
-    if hotkey::request_accessibility_permission() {
-        finish_accessibility_permission_granted();
-        return;
-    }
-
-    ensure_accessibility_permission_polling();
-}
-
-#[cfg(target_os = "macos")]
-fn ensure_accessibility_permission_polling() {
-    if ACCESSIBILITY_PERMISSION_POLLING.swap(true, Ordering::SeqCst) {
-        return;
-    }
-
-    std::thread::Builder::new()
-        .name("yap-accessibility-permission-wait".into())
-        .spawn(|| {
-            for _ in 0..120 {
-                if !RUNNING.load(Ordering::SeqCst) {
-                    ACCESSIBILITY_PERMISSION_POLLING.store(false, Ordering::SeqCst);
-                    return;
-                }
-                if hotkey::has_accessibility_permission() {
-                    finish_accessibility_permission_granted();
-                    return;
-                }
-                std::thread::sleep(Duration::from_secs(1));
-            }
-
-            ACCESSIBILITY_PERMISSION_POLLING.store(false, Ordering::SeqCst);
-            emit_overlay_permission(
-                "Accessibility Required",
-                "Allow Accessibility access to use the global hotkey anywhere.",
-                "Open Settings",
-                true,
-            );
-        })
-        .ok();
-}
-
-#[cfg(target_os = "macos")]
-fn finish_accessibility_permission_granted() {
-    ACCESSIBILITY_PERMISSION_POLLING.store(false, Ordering::SeqCst);
-    if !RUNNING.load(Ordering::SeqCst) {
-        return;
-    }
-    hotkey::stop();
     let cfg = config::get();
-    hotkey::start(HotkeySpec::parse(&cfg.hotkey));
-    emit_overlay_permission("", "", "", false);
-    emit(
-        "dictation:permission-granted",
-        json!({ "permission": "accessibility" }),
-    );
-
-    if !cfg.onboarding_complete && onboarding_step().is_none() {
-        set_onboarding_step(Some(OnboardingStep::TryIt));
-    }
+    let label = HotkeySpec::parse(&cfg.hotkey).label();
+    emit_accessibility_permission_required(&label);
 }
 
 pub fn stop() -> Result<(), String> {
@@ -220,8 +159,6 @@ pub fn stop() -> Result<(), String> {
     if let Ok(mut host) = HOST.lock() {
         *host = None;
     }
-    #[cfg(target_os = "macos")]
-    ACCESSIBILITY_PERMISSION_POLLING.store(false, Ordering::SeqCst);
     Ok(())
 }
 
@@ -1051,6 +988,13 @@ fn handle_overlay_event(event: String) {
                 is_hands_free_recording(),
                 matches!(state(), RuntimeState::Paused),
             );
+            #[cfg(target_os = "macos")]
+            {
+                if !hotkey::has_accessibility_permission() {
+                    let hotkey_label = HotkeySpec::parse(&cfg.hotkey).label();
+                    emit_accessibility_permission_required(&hotkey_label);
+                }
+            }
         }
         "pill_click" => on_overlay_pill_click(),
         #[cfg(target_os = "macos")]

--- a/desktop/native-core/src/hotkey.rs
+++ b/desktop/native-core/src/hotkey.rs
@@ -337,7 +337,6 @@ mod platform {
 
     // --- Raw CoreGraphics FFI bindings ---
 
-    type CFDictionaryRef = *const std::ffi::c_void;
     type CGEventRef = *mut std::ffi::c_void;
     type CGEventTapProxy = *mut std::ffi::c_void;
     type CFMachPortRef = *mut std::ffi::c_void;
@@ -413,20 +412,9 @@ mod platform {
             return_after_source_handled: u8,
         ) -> i32;
 
-        fn CFDictionaryCreate(
-            allocator: CFAllocatorRef,
-            keys: *const *const std::ffi::c_void,
-            values: *const *const std::ffi::c_void,
-            num_values: isize,
-            key_callbacks: *const std::ffi::c_void,
-            value_callbacks: *const std::ffi::c_void,
-        ) -> CFDictionaryRef;
-
         fn CFRelease(cf: *const std::ffi::c_void);
 
         fn AXIsProcessTrusted() -> bool;
-
-        fn AXIsProcessTrustedWithOptions(options: CFDictionaryRef) -> bool;
 
         // kCFRunLoopCommonModes is an external C symbol
         static kCFRunLoopCommonModes: CFStringRef;
@@ -434,9 +422,6 @@ mod platform {
 
         // kCFAllocatorDefault
         static kCFAllocatorDefault: CFAllocatorRef;
-
-        static kCFBooleanTrue: *const std::ffi::c_void;
-        static kAXTrustedCheckOptionPrompt: CFStringRef;
     }
 
     /// Track key held state.
@@ -508,7 +493,7 @@ mod platform {
         CURRENT_PRESS_IS_DOUBLE_TAP.store(false, Ordering::SeqCst);
         let generation = begin_listener_generation();
 
-        if !accessibility_trusted(false) {
+        if !accessibility_trusted() {
             eprintln!(
                 "[yap] HOTKEY WAITING: grant Accessibility permission to enable {}",
                 spec.label()
@@ -590,43 +575,12 @@ mod platform {
             .expect("failed to spawn hotkey thread");
     }
 
-    fn accessibility_trusted(prompt: bool) -> bool {
-        if !prompt {
-            return unsafe { AXIsProcessTrusted() };
-        }
-
-        unsafe {
-            let keys = [kAXTrustedCheckOptionPrompt as *const std::ffi::c_void];
-            let values = [kCFBooleanTrue];
-            let options = CFDictionaryCreate(
-                kCFAllocatorDefault,
-                keys.as_ptr(),
-                values.as_ptr(),
-                1,
-                std::ptr::null(),
-                std::ptr::null(),
-            );
-
-            let trusted = if options.is_null() {
-                AXIsProcessTrusted()
-            } else {
-                AXIsProcessTrustedWithOptions(options)
-            };
-
-            if !options.is_null() {
-                CFRelease(options);
-            }
-
-            trusted
-        }
+    fn accessibility_trusted() -> bool {
+        unsafe { AXIsProcessTrusted() }
     }
 
     pub fn has_accessibility_permission() -> bool {
-        accessibility_trusted(false)
-    }
-
-    pub fn request_accessibility_permission() -> bool {
-        accessibility_trusted(true)
+        accessibility_trusted()
     }
 
     /// C callback for the CGEventTap.
@@ -1333,15 +1287,5 @@ pub fn has_accessibility_permission() -> bool {
 
 #[cfg(not(target_os = "macos"))]
 pub fn has_accessibility_permission() -> bool {
-    true
-}
-
-#[cfg(target_os = "macos")]
-pub fn request_accessibility_permission() -> bool {
-    platform::request_accessibility_permission()
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn request_accessibility_permission() -> bool {
     true
 }

--- a/desktop/native-core/src/sidecar.rs
+++ b/desktop/native-core/src/sidecar.rs
@@ -188,11 +188,7 @@ fn resolve_sidecar_binary() -> Option<PathBuf> {
         "yap-overlay-x86_64-apple-darwin"
     };
 
-    let mut candidates = vec![
-        manifest_dir.join("sidecar-overlay/.build/debug/yap-overlay"),
-        manifest_dir.join("sidecar-overlay/.build/release/yap-overlay"),
-        manifest_dir.join("binaries").join(architecture_binary),
-    ];
+    let mut candidates = Vec::new();
 
     if let Ok(current_exe) = std::env::current_exe() {
         if let Some(parent) = current_exe.parent() {
@@ -200,6 +196,12 @@ fn resolve_sidecar_binary() -> Option<PathBuf> {
             candidates.push(parent.join(architecture_binary));
         }
     }
+
+    candidates.extend([
+        manifest_dir.join("binaries").join(architecture_binary),
+        manifest_dir.join("sidecar-overlay/.build/release/yap-overlay"),
+        manifest_dir.join("sidecar-overlay/.build/debug/yap-overlay"),
+    ]);
 
     candidates.into_iter().find(|path| path.exists())
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,6 +19,7 @@
     "electron:build-sidecar": "node scripts/build-sidecar.mjs",
     "electron:package": "pnpm run electron:build && pnpm run electron:build-core && pnpm run electron:build-sidecar && electron-builder --config electron-builder.yml",
     "electron:package:ci": "pnpm run electron:build && pnpm run electron:build-core && pnpm run electron:build-sidecar && electron-builder --config electron-builder.yml --publish never",
+    "electron:verify-mac-entitlements": "node scripts/verify-mac-entitlements.mjs",
     "electron:check": "tsc --noEmit --project tsconfig.electron.json"
   },
   "license": "MIT",

--- a/desktop/scripts/verify-mac-entitlements.mjs
+++ b/desktop/scripts/verify-mac-entitlements.mjs
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+const outputDir = resolve("release-electron");
+const requiredEntitlements = ["com.apple.security.device.audio-input"];
+
+if (process.platform !== "darwin") {
+  console.log("Skipping macOS entitlement verification on non-macOS host.");
+  process.exit(0);
+}
+
+const appPath = findNewestAppBundle(outputDir);
+if (!appPath) {
+  console.error(`Packaged Yap.app not found under: ${outputDir}`);
+  process.exit(1);
+}
+
+const targets = [
+  { label: "Yap.app", path: appPath },
+  { label: "yap-core", path: join(appPath, "Contents/Resources/bin/yap-core") },
+];
+
+for (const target of targets) {
+  if (!existsSync(target.path)) {
+    console.error(`Signed target not found: ${target.path}`);
+    process.exit(1);
+  }
+
+  const entitlements = execFileSync("codesign", ["-d", "--entitlements", ":-", target.path], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  for (const entitlement of requiredEntitlements) {
+    if (!entitlements.includes(`<key>${entitlement}</key>`)) {
+      console.error(`${target.label} is missing entitlement: ${entitlement}`);
+      process.exit(1);
+    }
+  }
+}
+
+execFileSync("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath], {
+  stdio: "inherit",
+});
+
+console.log(`macOS entitlements verified for ${appPath}.`);
+
+function findNewestAppBundle(root) {
+  const bundles = findAppBundles(root);
+  bundles.sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs);
+  return bundles[0] ?? null;
+}
+
+function findAppBundles(root) {
+  if (!existsSync(root)) return [];
+
+  const entries = readdirSync(root, { withFileTypes: true });
+  const bundles = [];
+
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (!entry.isDirectory()) continue;
+
+    if (basename(path) === "Yap.app") {
+      bundles.push(path);
+      continue;
+    }
+
+    bundles.push(...findAppBundles(path));
+  }
+
+  return bundles;
+}

--- a/desktop/src/lib/runtime/yap.ts
+++ b/desktop/src/lib/runtime/yap.ts
@@ -32,7 +32,6 @@ interface YapBridge {
   versions?: Record<string, string>;
   app?: {
     getInfo?: () => Promise<YapAppInfo>;
-    relaunch?: () => Promise<void>;
   };
   windows?: {
     openSettings?: () => Promise<void>;
@@ -189,13 +188,6 @@ export async function checkForRuntimeUpdate(options?: { timeout?: number }): Pro
   }
 
   return null;
-}
-
-export async function relaunchRuntime(): Promise<void> {
-  const electron = requiredElectronBridge();
-  if (electron?.app?.relaunch) {
-    await electron.app.relaunch();
-  }
 }
 
 export async function onRuntimeFocusChanged(handler: (focused: boolean) => void): Promise<Unlisten> {

--- a/desktop/src/lib/settings/Settings.svelte
+++ b/desktop/src/lib/settings/Settings.svelte
@@ -26,7 +26,6 @@
     listenRuntimeEvent,
     onRuntimeFocusChanged,
     openExternal,
-    relaunchRuntime,
     setAutostartEnabled,
     type RuntimeDownloadEvent,
     type RuntimeUpdate,
@@ -786,8 +785,6 @@
           updateMessage = 'Update installed. Restarting Yap...';
         }
       });
-
-      await relaunchRuntime();
     } catch (error) {
       updateStatus = 'error';
       updateMessage = updaterErrorMessage(error);


### PR DESCRIPTION
## Summary
- fix: move macOS Accessibility and microphone permission supervision into Electron main
- fix: make update install/restart flow main-process owned with structured updater logs
- fix: verify macOS app and native sidecar audio-input entitlements during packaging
- fix: repair hotkey capture and packaged overlay sidecar lookup reliability
- chore: remove legacy config migration and renderer relaunch cleanup paths
- chore: bump version to 3.0.3

## Testing
- [x] `cargo fmt --check --manifest-path desktop/native-core/Cargo.toml`
- [x] `cargo check --manifest-path desktop/native-core/Cargo.toml --bin yap-core`
- [x] `cargo test --manifest-path desktop/native-core/Cargo.toml`
- [x] `cd desktop && pnpm run electron:check`
- [x] `cd desktop && pnpm run check`
- [x] `git diff --check`
- [x] `cd desktop && pnpm run electron:package:ci`
- [x] `cd desktop && pnpm run electron:verify-mac-entitlements`
- [x] `desktop/release-electron/latest-mac.yml` points at `3.0.3` artifacts

## Version Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* fix: relaunch cleanly after Accessibility grant by @oobagi in this PR
* fix: request microphone permission during Electron startup by @oobagi in this PR
* fix: make updater install restart reliably by @oobagi in this PR
* fix: verify macOS microphone entitlements for app and sidecar by @oobagi in this PR
* fix: repair hotkey capture and packaged overlay lookup by @oobagi in this PR
* chore: remove legacy runtime cleanup paths by @oobagi in this PR
* chore: bump version to 3.0.3 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.2...v3.0.3
