### PR TITLE
Release v3.0.4

### DIFF
--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.3"
+version = "3.0.4"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",


### PR DESCRIPTION
## Summary
- fix: restore macOS on-device transcription with a Swift Speech helper
- fix: guard updater install when no update exists
- chore: bump version to 3.0.4

## Testing
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`

## Version Bump Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* fix: restore macOS on-device transcription by @oobagi in https://github.com/oobagi/yap/commit/4d01e78
* fix: guard updater install when no update exists by @oobagi in https://github.com/oobagi/yap/commit/92b38dc
* chore: bump version to 3.0.4 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.3...v3.0.4