### PR TITLE
Release v3.0.5

### DIFF
--- a/desktop/electron/main/index.ts
+++ b/desktop/electron/main/index.ts
@@ -7,7 +7,14 @@ import { isAccessibilityPayload, PermissionSupervisor } from "./permissions";
 import { relaunchApp } from "./relaunch";
 import { YapCoreSidecar } from "./sidecar";
 import { installTray, refreshHistoryMenu } from "./tray";
-import { createMainWindow, hideAppIfNoWindowsVisible, sendToAllWindows, sendToWindow, showAppWindow } from "./windows";
+import {
+  activateAppWindow,
+  createMainWindow,
+  hideAppIfNoWindowsVisible,
+  sendToAllWindows,
+  sendToWindow,
+  showAppWindow,
+} from "./windows";
 
 if (process.platform === "darwin") {
   app.commandLine.appendSwitch("use-mock-keychain");
@@ -40,7 +47,7 @@ app.whenReady().then(async () => {
 });
 
 app.on("activate", () => {
-  void showAppWindow("main");
+  void activateAppWindow();
 });
 
 app.on("window-all-closed", () => {

--- a/desktop/electron/main/windows.ts
+++ b/desktop/electron/main/windows.ts
@@ -29,13 +29,27 @@ export function windowLabelFor(webContentsId: number): WindowLabel {
 
 export async function showAppWindow(label: WindowLabel): Promise<BrowserWindow> {
   const window = label === "settings" ? await createSettingsWindow() : await createMainWindow();
+  presentWindow(window);
+  return window;
+}
+
+export async function activateAppWindow(): Promise<BrowserWindow> {
+  const settingsWindow = getWindow("settings");
+  if (settingsWindow?.isVisible() || settingsWindow?.isMinimized()) {
+    presentWindow(settingsWindow);
+    return settingsWindow;
+  }
+
+  return showAppWindow("settings");
+}
+
+function presentWindow(window: BrowserWindow): void {
   if (process.platform === "darwin") {
     app.dock?.show();
   }
   if (window.isMinimized()) window.restore();
   window.show();
   window.focus();
-  return window;
 }
 
 export function hideAppWindow(label: WindowLabel): void {

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.4"
+version = "3.0.5"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/native-core/sidecar-overlay/Sources/OverlayPanel.swift
+++ b/desktop/native-core/sidecar-overlay/Sources/OverlayPanel.swift
@@ -256,9 +256,12 @@ class OverlayPanel: NSPanel {
         updatePillTarget()
     }
 
-    func applyLevels(level: Float, bars: [Float]) {
+    func applyLevels(level: Float, bars: [Float], elapsed: Double) {
         overlayState.audioLevel = level
         overlayState.bandLevels = bars
+        if overlayState.mode == .recording {
+            overlayState.handsFreeElapsed = elapsed
+        }
         updateButtonTargets()
     }
 
@@ -620,7 +623,7 @@ struct OverlayView: View {
                             .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .bottom)))
                     }
 
-                    if state.mode == .recording && state.handsFreeElapsed >= 10 {
+                    if state.mode == .recording && state.isHandsFree {
                         Text(formatElapsed(state.handsFreeElapsed))
                             .font(.system(size: 11, weight: .medium, design: .monospaced))
                             .foregroundColor(.white.opacity(0.5))
@@ -687,7 +690,7 @@ struct OverlayView: View {
                 .offset(y: stackYOffset)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: state.onboardingStep)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: state.mode)
-                .animation(.spring(response: 0.45, dampingFraction: 0.7), value: state.mode == .recording && state.handsFreeElapsed >= 10)
+                .animation(.spring(response: 0.45, dampingFraction: 0.7), value: state.mode == .recording && state.isHandsFree)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: stackYOffset)
 
                 Spacer().frame(height: OverlayLayout.bottomSpacerHeight)

--- a/desktop/native-core/sidecar-overlay/Sources/main.swift
+++ b/desktop/native-core/sidecar-overlay/Sources/main.swift
@@ -42,7 +42,8 @@ DispatchQueue.global(qos: .userInteractive).async {
             case "levels":
                 panel.applyLevels(
                     level: msg.level ?? 0,
-                    bars: msg.bars ?? Array(repeating: 0, count: 11)
+                    bars: msg.bars ?? Array(repeating: 0, count: 11),
+                    elapsed: msg.elapsed ?? 0
                 )
 
             case "error":

--- a/desktop/native-core/src/dictation.rs
+++ b/desktop/native-core/src/dictation.rs
@@ -871,6 +871,7 @@ fn start_level_poller() {
             }
 
             let levels = audio::get_levels();
+            let elapsed = recording_elapsed_seconds();
             update_peak_level(levels.level);
             emit(
                 "dictation:levels",
@@ -879,7 +880,7 @@ fn start_level_poller() {
                     "bars": levels.bars,
                 }),
             );
-            emit_overlay_levels(levels.level, levels.bars.to_vec());
+            emit_overlay_levels(levels.level, levels.bars.to_vec(), elapsed);
         })
         .ok();
 }
@@ -963,14 +964,14 @@ fn spawn_overlay(_cfg: &AppConfig) {}
 #[cfg(target_os = "macos")]
 fn stop_overlay() {
     emit_overlay_state("idle".to_string(), false, false);
-    emit_overlay_levels(0.0, vec![0.0; 11]);
+    emit_overlay_levels(0.0, vec![0.0; 11], 0.0);
     crate::sidecar::stop();
 }
 
 #[cfg(target_os = "windows")]
 fn stop_overlay() {
     emit_overlay_state("idle".to_string(), false, false);
-    emit_overlay_levels(0.0, vec![0.0; 11]);
+    emit_overlay_levels(0.0, vec![0.0; 11], 0.0);
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -1058,14 +1059,19 @@ fn emit_overlay_state(state: String, hands_free: bool, paused: bool) {
 fn emit_overlay_state(_state: String, _hands_free: bool, _paused: bool) {}
 
 #[cfg(target_os = "macos")]
-fn emit_overlay_levels(level: f32, bars: Vec<f32>) {
-    crate::sidecar::send(&crate::sidecar::OutMessage::Levels { level, bars });
+fn emit_overlay_levels(level: f32, bars: Vec<f32>, elapsed: f64) {
+    crate::sidecar::send(&crate::sidecar::OutMessage::Levels {
+        level,
+        bars,
+        elapsed,
+    });
 }
 
 #[cfg(target_os = "windows")]
-fn emit_overlay_levels(level: f32, bars: Vec<f32>) {
+fn emit_overlay_levels(level: f32, bars: Vec<f32>, elapsed: f64) {
     crate::win_overlay::update_state(|overlay| {
         overlay.level = level;
+        overlay.elapsed = elapsed;
         if bars.len() == 11 {
             overlay.bars.copy_from_slice(&bars);
         }
@@ -1073,7 +1079,7 @@ fn emit_overlay_levels(level: f32, bars: Vec<f32>) {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn emit_overlay_levels(_level: f32, _bars: Vec<f32>) {}
+fn emit_overlay_levels(_level: f32, _bars: Vec<f32>, _elapsed: f64) {}
 
 #[cfg(target_os = "macos")]
 fn emit_overlay_error(message: &str) {

--- a/desktop/native-core/src/sidecar.rs
+++ b/desktop/native-core/src/sidecar.rs
@@ -38,6 +38,7 @@ pub enum OutMessage {
     Levels {
         level: f32,
         bars: Vec<f32>,
+        elapsed: f64,
     },
     Error {
         message: String,

--- a/desktop/native-core/src/win_overlay.rs
+++ b/desktop/native-core/src/win_overlay.rs
@@ -1359,7 +1359,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
     }
 
     // -- Elapsed time (above pill, hands-free) --
-    if state.mode == "recording" && state.elapsed >= 10.0 {
+    if state.mode == "recording" && state.hands_free {
         if let Some(ref fr) = font {
             let elapsed_text = format_elapsed(state.elapsed);
             fr.render_centered(

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",


### PR DESCRIPTION
## Summary
- fix: focus Settings when Yap is activated from the macOS Dock instead of showing the hidden runtime window
- fix: keep the hands-free recording timer visible and counting by refreshing overlay elapsed time from the runtime level poll
- chore: bump version to 3.0.5

## Testing
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`
- [x] `pnpm run electron:build-sidecar`
- [x] `pnpm run electron:package:ci`
- [x] `git diff --check`

## Version Bump Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* fix: focus Settings from macOS Dock activation by @oobagi in this PR
* fix: keep the hands-free timer visible and counting by @oobagi in this PR
* chore: bump version to 3.0.5 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.4...v3.0.5
