### PR TITLE
Release v3.0.6

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -75,10 +75,62 @@ jobs:
         shell: bash
         run: rm -rf release-electron dist-electron
 
+      - name: Check macOS release signing secrets
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
+        run: |
+          missing=()
+          [[ -n "$CSC_LINK" ]] || missing+=(CSC_LINK)
+          [[ -n "$CSC_KEY_PASSWORD" ]] || missing+=(CSC_KEY_PASSWORD)
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing macOS signing secret(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          has_api_key=false
+          if [[ -n "$APPLE_API_KEY" && -n "$APPLE_API_KEY_ID" && -n "$APPLE_API_ISSUER" ]]; then
+            has_api_key=true
+          fi
+
+          has_apple_id=false
+          if [[ -n "$APPLE_ID" && -n "$APPLE_APP_SPECIFIC_PASSWORD" && -n "$APPLE_TEAM_ID" ]]; then
+            has_apple_id=true
+          fi
+
+          has_keychain_profile=false
+          if [[ -n "$APPLE_KEYCHAIN_PROFILE" ]]; then
+            has_keychain_profile=true
+          fi
+
+          if [[ "$has_api_key" != true && "$has_apple_id" != true && "$has_keychain_profile" != true ]]; then
+            echo "Missing notarization credentials. Set APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER, APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID, or APPLE_KEYCHAIN_PROFILE." >&2
+            exit 1
+          fi
+
       - name: Package Electron app
         working-directory: desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_KEYCHAIN: ${{ secrets.APPLE_KEYCHAIN }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
         run: pnpm run electron:package:ci
 
       - name: Verify macOS entitlements

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -30,6 +30,7 @@ mac:
   icon: native-core/icons/icon.icns
   entitlements: electron/entitlements.mac.plist
   entitlementsInherit: electron/entitlements.mac.inherit.plist
+  notarize: true
   extendInfo:
     NSMicrophoneUsageDescription: Yap records your voice so it can transcribe and paste what you say.
     NSSpeechRecognitionUsageDescription: Yap uses speech recognition to transcribe audio locally when available.

--- a/desktop/electron/main/updater.ts
+++ b/desktop/electron/main/updater.ts
@@ -1,12 +1,33 @@
+import { spawnSync } from "node:child_process";
 import { app, type WebContents } from "electron";
 import electronUpdater from "electron-updater";
 import { allowWindowCloseForQuit } from "./windows";
 
 const { autoUpdater } = electronUpdater;
+const INSTALL_HANDOFF_TIMEOUT_MS = 120_000;
+
+type DownloadProgress = {
+  total?: number;
+  transferred?: number;
+  delta?: number;
+  percent?: number;
+  bytesPerSecond?: number;
+};
+
+type UpdateFileInfo = {
+  url?: string;
+  size?: number;
+};
+
+type UpdateInfoWithFiles = {
+  files?: UpdateFileInfo[];
+  path?: string;
+};
 
 export function configureUpdater(): void {
   autoUpdater.autoDownload = false;
-  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.autoInstallOnAppQuit = false;
+  autoUpdater.autoRunAppAfterInstall = true;
 }
 
 export async function checkForElectronUpdate(): Promise<{ version: string } | null> {
@@ -21,68 +42,167 @@ export async function checkForElectronUpdate(): Promise<{ version: string } | nu
 
 export async function downloadAndInstallElectronUpdate(sender: WebContents): Promise<null> {
   if (!app.isPackaged) return null;
+  assertCanUseInAppInstaller();
 
   const result = await autoUpdater.checkForUpdates();
   if (!result?.isUpdateAvailable) {
     throw new Error("No update is available to install. Check for updates again.");
   }
 
+  const contentLength = updateContentLength(result.updateInfo);
   let transferred = 0;
   console.info("[yap-updater] starting update download");
   sender.send("yap:updater-download", {
     event: "Started",
-    data: {},
+    data: {
+      contentLength,
+      total: contentLength,
+    },
   });
 
   return new Promise((resolve, reject) => {
-    const cleanup = () => {
+    let settled = false;
+    let installTimer: NodeJS.Timeout | undefined;
+
+    const cleanupDownloadListeners = () => {
       autoUpdater.off("download-progress", onProgress);
       autoUpdater.off("update-downloaded", onDownloaded);
-      autoUpdater.off("error", onError);
     };
-    const onProgress = (progress: { total?: number; transferred?: number }) => {
+    const cleanup = () => {
+      cleanupDownloadListeners();
+      autoUpdater.off("error", onError);
+      app.off("before-quit", onBeforeQuit);
+      if (installTimer) {
+        clearTimeout(installTimer);
+        installTimer = undefined;
+      }
+    };
+    const resolveOnce = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(null);
+    };
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onBeforeQuit = () => {
+      console.info("[yap-updater] app is quitting for update install");
+      resolveOnce();
+    };
+    const onProgress = (progress: DownloadProgress) => {
       const nextTransferred = progress.transferred ?? transferred;
-      const chunkLength = Math.max(0, nextTransferred - transferred);
+      const chunkLength = Math.max(0, progress.delta ?? nextTransferred - transferred);
       transferred = nextTransferred;
       sender.send("yap:updater-download", {
         event: "Progress",
         data: {
           contentLength: progress.total,
           chunkLength,
+          transferred: nextTransferred,
+          total: progress.total,
+          percent: progress.percent,
+          bytesPerSecond: progress.bytesPerSecond,
         },
       });
     };
     const onDownloaded = () => {
-      cleanup();
+      cleanupDownloadListeners();
       console.info("[yap-updater] update download completed");
       sender.send("yap:updater-download", {
         event: "Finished",
-        data: {},
+        data: {
+          contentLength,
+          total: contentLength,
+          transferred,
+          percent: 100,
+        },
       });
       allowWindowCloseForQuit();
       try {
         console.info("[yap-updater] calling quitAndInstall");
-        autoUpdater.quitAndInstall(false, true);
+        if (process.platform === "darwin") {
+          autoUpdater.quitAndInstall();
+        } else {
+          autoUpdater.quitAndInstall(false, true);
+        }
       } catch (error) {
         console.error("[yap-updater] quitAndInstall failed:", error);
-        reject(error);
+        rejectOnce(error);
         return;
       }
-      setTimeout(() => {
-        console.warn("[yap-updater] quitAndInstall did not exit promptly; falling back to app.quit");
-        app.quit();
-      }, 5000).unref();
-      resolve(null);
+      installTimer = setTimeout(() => {
+        rejectOnce(new Error("The update installer did not start. Restart Yap and try again."));
+      }, INSTALL_HANDOFF_TIMEOUT_MS);
+      installTimer.unref();
     };
     const onError = (error: Error) => {
-      cleanup();
       console.error("[yap-updater] update install failed:", error);
-      reject(error);
+      rejectOnce(error);
     };
 
     autoUpdater.on("download-progress", onProgress);
     autoUpdater.once("update-downloaded", onDownloaded);
     autoUpdater.once("error", onError);
-    autoUpdater.downloadUpdate().catch(onError);
+    app.once("before-quit", onBeforeQuit);
+    autoUpdater.downloadUpdate().catch((error: unknown) => {
+      onError(normalizeError(error));
+    });
   });
+}
+
+function updateContentLength(updateInfo: unknown): number | undefined {
+  const info = updateInfo as UpdateInfoWithFiles | undefined;
+  const files = info?.files ?? [];
+  const preferredFile =
+    files.find((file) => typeof file.url === "string" && file.url.endsWith(".zip")) ?? files[0];
+
+  return positiveNumber(preferredFile?.size);
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
+}
+
+function assertCanUseInAppInstaller(): void {
+  if (process.platform !== "darwin") return;
+
+  const appBundlePath = macAppBundlePath();
+  if (!appBundlePath) return;
+
+  let signatureDetails: string;
+  try {
+    const result = spawnSync("codesign", ["-dv", "--verbose=4", appBundlePath], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    signatureDetails = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    if (result.error) throw result.error;
+    if (result.status !== 0) throw new Error(signatureDetails);
+  } catch (error) {
+    throw new Error(
+      `This copy of Yap cannot use in-app updates because macOS could not verify its signature: ${normalizeError(error).message}`
+    );
+  }
+
+  if (!/^Authority=Developer ID Application:/m.test(signatureDetails)) {
+    throw new Error(
+      "This copy of Yap is not signed for in-app updates. Install the latest signed release manually once, then in-app updates will work."
+    );
+  }
+}
+
+function macAppBundlePath(): string | null {
+  const marker = "/Contents/MacOS/";
+  const executablePath = app.getPath("exe");
+  const markerIndex = executablePath.indexOf(marker);
+  return markerIndex === -1 ? null : executablePath.slice(0, markerIndex);
 }

--- a/desktop/electron/preload/types.ts
+++ b/desktop/electron/preload/types.ts
@@ -18,6 +18,10 @@ export interface YapDownloadEvent {
   data?: {
     contentLength?: number;
     chunkLength?: number;
+    transferred?: number;
+    total?: number;
+    percent?: number;
+    bytesPerSecond?: number;
   };
 }
 

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.5"
+version = "3.0.6"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",

--- a/desktop/scripts/verify-mac-entitlements.mjs
+++ b/desktop/scripts/verify-mac-entitlements.mjs
@@ -1,8 +1,10 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 
 const outputDir = resolve("release-electron");
+const requireTrustedSigning =
+  process.env.YAP_REQUIRE_MAC_SIGNING === "1" || process.env.GITHUB_REF?.startsWith("refs/tags/v");
 const requiredEntitlements = [
   "com.apple.security.device.audio-input",
   "com.apple.security.personal-information.speech-recognition",
@@ -54,7 +56,59 @@ execFileSync("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPa
   stdio: "inherit",
 });
 
+if (requireTrustedSigning) {
+  verifyTrustedMacSignature(appPath);
+}
+
 console.log(`macOS entitlements verified for ${appPath}.`);
+
+function verifyTrustedMacSignature(appPath) {
+  const signatureDetails = capture("codesign", ["-dv", "--verbose=4", appPath]);
+
+  if (/^Signature=adhoc$/m.test(signatureDetails)) {
+    fail("Yap.app is ad-hoc signed. Release builds need a Developer ID Application certificate.");
+  }
+
+  if (!/^Authority=Developer ID Application:/m.test(signatureDetails)) {
+    fail("Yap.app is not signed with a Developer ID Application identity.");
+  }
+
+  const teamIdentifier = signatureDetails.match(/^TeamIdentifier=(.+)$/m)?.[1]?.trim();
+  if (!teamIdentifier || teamIdentifier === "not set") {
+    fail("Yap.app has no TeamIdentifier. Release builds need a trusted Apple signing identity.");
+  }
+
+  try {
+    execFileSync("spctl", ["--assess", "--type", "execute", "--verbose=4", appPath], {
+      stdio: "inherit",
+    });
+  } catch {
+    fail("Gatekeeper rejected Yap.app. Release builds need successful notarization/stapling.");
+  }
+}
+
+function capture(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  if (result.error) {
+    fail(`${command} failed: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    fail(`${command} ${args.join(" ")} failed:\n${output}`);
+  }
+
+  return output;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
 
 function findNewestAppBundle(root) {
   const bundles = findAppBundles(root);

--- a/desktop/src/lib/runtime/yap.ts
+++ b/desktop/src/lib/runtime/yap.ts
@@ -5,6 +5,10 @@ export interface RuntimeDownloadEvent {
   data?: {
     contentLength?: number;
     chunkLength?: number;
+    transferred?: number;
+    total?: number;
+    percent?: number;
+    bytesPerSecond?: number;
   };
 }
 

--- a/desktop/src/lib/settings/Settings.svelte
+++ b/desktop/src/lib/settings/Settings.svelte
@@ -150,6 +150,7 @@
   let updateVersion = $state('');
   let updateDownloaded = $state(0);
   let updateTotal = $state<number | null>(null);
+  let updatePercent = $state<number | null>(null);
   let pendingUpdate: RuntimeUpdate | null = null;
 
   // ── Derived ───────────────────────────────────────────────────────────
@@ -698,14 +699,28 @@
 
   function updateProgress(): number {
     if (updateStatus === 'ready') return 100;
+    if (updatePercent !== null) return clampPercent(updatePercent);
     if (!updateTotal || updateTotal <= 0) return 0;
-    return Math.max(0, Math.min(100, Math.round((updateDownloaded / updateTotal) * 100)));
+    return clampPercent((updateDownloaded / updateTotal) * 100);
   }
 
   function updateProgressLabel(): string {
-    if (updateStatus === 'ready') return 'Installed';
+    if (updateStatus === 'ready') return 'Installing';
+    if (!updateTotal && updatePercent !== null) return `${updateProgress()}%`;
     if (!updateTotal) return formatBytes(updateDownloaded);
     return `${formatBytes(updateDownloaded)} of ${formatBytes(updateTotal)}`;
+  }
+
+  function clampPercent(value: number): number {
+    return Math.max(0, Math.min(100, Math.round(value)));
+  }
+
+  function positiveNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+  }
+
+  function nonNegativeNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
   }
 
   function formatBytes(bytes: number): string {
@@ -733,6 +748,7 @@
     updateVersion = '';
     updateDownloaded = 0;
     updateTotal = null;
+    updatePercent = null;
     updateStatus = 'checking';
     updateMessage = 'Checking for updates...';
 
@@ -770,19 +786,28 @@
     updateStatus = 'downloading';
     updateDownloaded = 0;
     updateTotal = null;
+    updatePercent = null;
     updateMessage = `Downloading Yap ${version}...`;
 
     try {
       const update = pendingUpdate;
       await update.downloadAndInstall((event: RuntimeDownloadEvent) => {
+        const data = event.data ?? {};
         if (event.event === 'Started') {
-          updateTotal = event.data?.contentLength ?? null;
+          updateTotal = positiveNumber(data.total ?? data.contentLength);
           updateDownloaded = 0;
+          updatePercent = null;
         } else if (event.event === 'Progress') {
-          updateDownloaded += event.data?.chunkLength ?? 0;
+          updateTotal = positiveNumber(data.total ?? data.contentLength) ?? updateTotal;
+          updateDownloaded =
+            nonNegativeNumber(data.transferred) ?? updateDownloaded + (data.chunkLength ?? 0);
+          updatePercent = nonNegativeNumber(data.percent) ?? updatePercent;
         } else if (event.event === 'Finished') {
+          updateTotal = positiveNumber(data.total ?? data.contentLength) ?? updateTotal;
+          updateDownloaded = nonNegativeNumber(data.transferred) ?? updateDownloaded;
+          updatePercent = 100;
           updateStatus = 'ready';
-          updateMessage = 'Update installed. Restarting Yap...';
+          updateMessage = 'Download finished. Installing update...';
         }
       });
     } catch (error) {
@@ -1549,7 +1574,7 @@
               {#if updateStatus === 'downloading' || updateStatus === 'ready'}
                 <div class="update-progress" aria-label="Update progress">
                   <div class="update-progress-header">
-                    <span>{updateStatus === 'ready' ? 'Installed' : 'Downloading'}</span>
+                    <span>{updateStatus === 'ready' ? 'Installing' : 'Downloading'}</span>
                     <span>{updateProgressLabel()}</span>
                   </div>
                   <div class="update-progress-track">


### PR DESCRIPTION
## Summary
- fix: harden in-app updater progress and macOS install handoff
- ci: require signed and notarized macOS release artifacts
- chore: bump version to 3.0.6

## Testing
- [x] `git diff --check`
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`

## Version Bump Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* fix: harden in-app update install flow by @oobagi in this PR
* ci: require trusted macOS release signing by @oobagi in this PR
* chore: bump version to 3.0.6 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.5...v3.0.6