### PR TITLE
Release v3.0.7

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -75,8 +75,8 @@ jobs:
         shell: bash
         run: rm -rf release-electron dist-electron
 
-      - name: Check macOS release signing secrets
-        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')
+      - name: Check macOS auto-update signing secrets
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v') && vars.YAP_PUBLISH_MAC_AUTO_UPDATE == 'true'
         shell: bash
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -120,7 +120,7 @@ jobs:
       - name: Package Electron app
         working-directory: desktop
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/v') && vars.YAP_PUBLISH_MAC_AUTO_UPDATE == 'true' && 'true' || 'false' }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
@@ -136,7 +136,15 @@ jobs:
       - name: Verify macOS entitlements
         if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')
         working-directory: desktop
+        env:
+          YAP_REQUIRE_MAC_TRUSTED_SIGNING: ${{ vars.YAP_PUBLISH_MAC_AUTO_UPDATE == 'true' && '1' || '0' }}
         run: pnpm run electron:verify-mac-entitlements
+
+      - name: Remove unsigned macOS update metadata
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v') && vars.YAP_PUBLISH_MAC_AUTO_UPDATE != 'true'
+        working-directory: desktop
+        shell: bash
+        run: rm -f release-electron/latest-mac.yml release-electron/*.dmg.blockmap release-electron/*.zip.blockmap
 
       - name: Upload Electron artifacts
         uses: actions/upload-artifact@v4

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -30,7 +30,6 @@ mac:
   icon: native-core/icons/icon.icns
   entitlements: electron/entitlements.mac.plist
   entitlementsInherit: electron/entitlements.mac.inherit.plist
-  notarize: true
   extendInfo:
     NSMicrophoneUsageDescription: Yap records your voice so it can transcribe and paste what you say.
     NSSpeechRecognitionUsageDescription: Yap uses speech recognition to transcribe audio locally when available.

--- a/desktop/electron/main/updater.ts
+++ b/desktop/electron/main/updater.ts
@@ -5,6 +5,15 @@ import { allowWindowCloseForQuit } from "./windows";
 
 const { autoUpdater } = electronUpdater;
 const INSTALL_HANDOFF_TIMEOUT_MS = 120_000;
+const GITHUB_RELEASES_URL = "https://github.com/oobagi/yap/releases/latest";
+const GITHUB_LATEST_RELEASE_API_URL = "https://api.github.com/repos/oobagi/yap/releases/latest";
+const RELEASE_CHECK_TIMEOUT_MS = 15_000;
+
+type ElectronUpdate = {
+  version: string;
+  canInstallInApp: boolean;
+  releaseUrl?: string;
+};
 
 type DownloadProgress = {
   total?: number;
@@ -24,20 +33,29 @@ type UpdateInfoWithFiles = {
   path?: string;
 };
 
+type GitHubReleaseInfo = {
+  tag_name?: string;
+  html_url?: string;
+};
+
 export function configureUpdater(): void {
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
   autoUpdater.autoRunAppAfterInstall = true;
 }
 
-export async function checkForElectronUpdate(): Promise<{ version: string } | null> {
+export async function checkForElectronUpdate(): Promise<ElectronUpdate | null> {
   if (!app.isPackaged) return null;
+
+  if (!canUseInAppInstaller()) {
+    return checkLatestGitHubRelease();
+  }
 
   const result = await autoUpdater.checkForUpdates();
   if (!result?.isUpdateAvailable) return null;
 
   const version = result?.updateInfo?.version;
-  return version ? { version } : null;
+  return version ? { version, canInstallInApp: true } : null;
 }
 
 export async function downloadAndInstallElectronUpdate(sender: WebContents): Promise<null> {
@@ -173,10 +191,22 @@ function normalizeError(error: unknown): Error {
 }
 
 function assertCanUseInAppInstaller(): void {
-  if (process.platform !== "darwin") return;
+  if (canUseInAppInstaller()) return;
 
+  throw new Error(
+    "This copy of Yap is unsigned, so it cannot install macOS updates in-app. Download the latest release from GitHub Releases."
+  );
+}
+
+function canUseInAppInstaller(): boolean {
+  if (process.platform !== "darwin") return true;
+
+  return hasDeveloperIdSignature();
+}
+
+function hasDeveloperIdSignature(): boolean {
   const appBundlePath = macAppBundlePath();
-  if (!appBundlePath) return;
+  if (!appBundlePath) return true;
 
   let signatureDetails: string;
   try {
@@ -188,16 +218,69 @@ function assertCanUseInAppInstaller(): void {
     if (result.error) throw result.error;
     if (result.status !== 0) throw new Error(signatureDetails);
   } catch (error) {
-    throw new Error(
-      `This copy of Yap cannot use in-app updates because macOS could not verify its signature: ${normalizeError(error).message}`
+    console.warn(
+      `[yap-updater] macOS signature check failed; using manual update mode: ${normalizeError(error).message}`
     );
+    return false;
   }
 
-  if (!/^Authority=Developer ID Application:/m.test(signatureDetails)) {
-    throw new Error(
-      "This copy of Yap is not signed for in-app updates. Install the latest signed release manually once, then in-app updates will work."
-    );
+  return /^Authority=Developer ID Application:/m.test(signatureDetails);
+}
+
+async function checkLatestGitHubRelease(): Promise<ElectronUpdate | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RELEASE_CHECK_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(GITHUB_LATEST_RELEASE_API_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "Yap updater",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub Releases returned HTTP ${response.status}`);
+    }
+
+    const release = (await response.json()) as GitHubReleaseInfo;
+    const version = normalizeVersion(release.tag_name);
+    if (!version || compareVersions(version, app.getVersion()) <= 0) return null;
+
+    return {
+      version,
+      canInstallInApp: false,
+      releaseUrl: release.html_url ?? GITHUB_RELEASES_URL,
+    };
+  } finally {
+    clearTimeout(timeout);
   }
+}
+
+function normalizeVersion(value: string | undefined): string | null {
+  const version = value?.trim().replace(/^v/i, "");
+  return version && /^\d+\.\d+\.\d+(?:[-+].+)?$/.test(version) ? version : null;
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = parseVersionParts(left);
+  const rightParts = parseVersionParts(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    const delta = leftParts[index] - rightParts[index];
+    if (delta !== 0) return delta;
+  }
+
+  return 0;
+}
+
+function parseVersionParts(version: string): [number, number, number] {
+  const [major = "0", minor = "0", patch = "0"] = version.split(/[+-]/)[0].split(".");
+  return [major, minor, patch].map((part) => Number.parseInt(part, 10) || 0) as [
+    number,
+    number,
+    number,
+  ];
 }
 
 function macAppBundlePath(): string | null {

--- a/desktop/electron/preload/index.ts
+++ b/desktop/electron/preload/index.ts
@@ -115,10 +115,16 @@ const bridge: YapBridge = {
   },
   updater: {
     check: async () => {
-      const update = await invoke<{ version: string } | null>("updater.check");
+      const update = await invoke<{
+        version: string;
+        canInstallInApp?: boolean;
+        releaseUrl?: string;
+      } | null>("updater.check");
       if (!update) return null;
       return {
         version: update.version,
+        canInstallInApp: update.canInstallInApp ?? true,
+        releaseUrl: update.releaseUrl,
         downloadAndInstall: async (onEvent) => {
           updaterDownloadHandler = onEvent ?? null;
           try {

--- a/desktop/electron/preload/types.ts
+++ b/desktop/electron/preload/types.ts
@@ -27,6 +27,8 @@ export interface YapDownloadEvent {
 
 export interface YapUpdate {
   version: string;
+  canInstallInApp: boolean;
+  releaseUrl?: string;
   downloadAndInstall(onEvent?: (event: YapDownloadEvent) => void): Promise<void>;
 }
 

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.6"
+version = "3.0.7"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",

--- a/desktop/scripts/verify-mac-entitlements.mjs
+++ b/desktop/scripts/verify-mac-entitlements.mjs
@@ -4,7 +4,7 @@ import { basename, join, resolve } from "node:path";
 
 const outputDir = resolve("release-electron");
 const requireTrustedSigning =
-  process.env.YAP_REQUIRE_MAC_SIGNING === "1" || process.env.GITHUB_REF?.startsWith("refs/tags/v");
+  process.env.YAP_REQUIRE_MAC_TRUSTED_SIGNING === "1" || process.env.YAP_REQUIRE_MAC_SIGNING === "1";
 const requiredEntitlements = [
   "com.apple.security.device.audio-input",
   "com.apple.security.personal-information.speech-recognition",
@@ -66,7 +66,9 @@ function verifyTrustedMacSignature(appPath) {
   const signatureDetails = capture("codesign", ["-dv", "--verbose=4", appPath]);
 
   if (/^Signature=adhoc$/m.test(signatureDetails)) {
-    fail("Yap.app is ad-hoc signed. Release builds need a Developer ID Application certificate.");
+    fail(
+      "Yap.app is ad-hoc signed. macOS auto-update release builds need a Developer ID Application certificate."
+    );
   }
 
   if (!/^Authority=Developer ID Application:/m.test(signatureDetails)) {
@@ -75,7 +77,7 @@ function verifyTrustedMacSignature(appPath) {
 
   const teamIdentifier = signatureDetails.match(/^TeamIdentifier=(.+)$/m)?.[1]?.trim();
   if (!teamIdentifier || teamIdentifier === "not set") {
-    fail("Yap.app has no TeamIdentifier. Release builds need a trusted Apple signing identity.");
+    fail("Yap.app has no TeamIdentifier. macOS auto-update release builds need a trusted Apple signing identity.");
   }
 
   try {
@@ -83,7 +85,7 @@ function verifyTrustedMacSignature(appPath) {
       stdio: "inherit",
     });
   } catch {
-    fail("Gatekeeper rejected Yap.app. Release builds need successful notarization/stapling.");
+    fail("Gatekeeper rejected Yap.app. macOS auto-update release builds need successful notarization/stapling.");
   }
 }
 

--- a/desktop/src/lib/runtime/yap.ts
+++ b/desktop/src/lib/runtime/yap.ts
@@ -14,6 +14,8 @@ export interface RuntimeDownloadEvent {
 
 export interface RuntimeUpdate {
   version: string;
+  canInstallInApp: boolean;
+  releaseUrl?: string;
   downloadAndInstall(onEvent?: (event: RuntimeDownloadEvent) => void): Promise<void>;
 }
 

--- a/desktop/src/lib/settings/Settings.svelte
+++ b/desktop/src/lib/settings/Settings.svelte
@@ -59,6 +59,7 @@
   const defaultTxProvider = isWindows ? 'openai' : 'none';
   const buildLabel = `v${__APP_VERSION__} (${__GIT_COMMIT_SHORT__})`;
   const buildUrl = __GITHUB_COMMIT_URL__;
+  const releasesUrl = 'https://github.com/oobagi/yap/releases/latest';
 
   const txProviders = transcriptionProviders(isWindows);
 
@@ -146,7 +147,7 @@
 
   // Updates
   let updateStatus = $state<UpdateStatus>('idle');
-  let updateMessage = $state('Check for a signed Yap release from GitHub.');
+  let updateMessage = $state('Check for updates from GitHub Releases.');
   let updateVersion = $state('');
   let updateDownloaded = $state(0);
   let updateTotal = $state<number | null>(null);
@@ -711,6 +712,10 @@
     return `${formatBytes(updateDownloaded)} of ${formatBytes(updateTotal)}`;
   }
 
+  function canInstallPendingUpdateInApp(): boolean {
+    return pendingUpdate?.canInstallInApp ?? true;
+  }
+
   function clampPercent(value: number): number {
     return Math.max(0, Math.min(100, Math.round(value)));
   }
@@ -733,7 +738,7 @@
   function updaterErrorMessage(error: unknown): string {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes('latest-mac.yml') || message.includes('latest.yml') || message.includes('update metadata')) {
-      return 'No signed update metadata is available yet. Try again after the next release finishes.';
+      return 'No in-app update metadata is available. Download the latest release from GitHub Releases.';
     }
     if (message.includes('signature')) {
       return 'The update could not be verified, so Yap did not install it.';
@@ -764,7 +769,9 @@
       pendingUpdate = update;
       updateVersion = update.version;
       updateStatus = 'available';
-      updateMessage = `Yap ${update.version} is ready to install.`;
+      updateMessage = update.canInstallInApp
+        ? `Yap ${update.version} is ready to install.`
+        : `Yap ${update.version} is available from GitHub Releases.`;
     } catch (error) {
       pendingUpdate = null;
       updateStatus = 'error';
@@ -775,6 +782,10 @@
 
   async function installUpdate() {
     if (!pendingUpdate || updateBusy()) return;
+    if (!pendingUpdate.canInstallInApp) {
+      await openUpdateRelease();
+      return;
+    }
 
     const version = pendingUpdate.version;
     const confirmed = await confirmAction(
@@ -814,6 +825,18 @@
       updateStatus = 'error';
       updateMessage = updaterErrorMessage(error);
       console.error('Failed to install update:', error);
+    }
+  }
+
+  async function openUpdateRelease() {
+    if (!pendingUpdate) return;
+
+    try {
+      await openExternal(pendingUpdate.releaseUrl ?? releasesUrl);
+    } catch (error) {
+      updateStatus = 'error';
+      updateMessage = 'Could not open GitHub Releases.';
+      console.error('Failed to open update release:', error);
     }
   }
 
@@ -1562,7 +1585,7 @@
                 </div>
                 {#if updateStatus === 'available'}
                   <button class="btn btn-primary" onclick={installUpdate} type="button">
-                    Install Update
+                    {canInstallPendingUpdateInApp() ? 'Install Update' : 'Open Release'}
                   </button>
                 {:else}
                   <button class="btn btn-secondary" onclick={checkForUpdates} type="button" disabled={updateBusy()}>
@@ -1585,7 +1608,11 @@
 
               {#if updateStatus === 'available' && updateVersion}
                 <div class="section-footer">
-                  Version {updateVersion} will be verified before it is installed.
+                  {#if canInstallPendingUpdateInApp()}
+                    Version {updateVersion} will be verified before it is installed.
+                  {:else}
+                    Install the downloaded app manually to update this unsigned macOS build.
+                  {/if}
                 </div>
               {:else if updateStatus === 'error'}
                 <div class="section-footer update-error">


### PR DESCRIPTION
## Summary
- fix: route unsigned macOS update checks to GitHub Releases and open the release page instead of attempting an in-app install
- ci: publish unsigned macOS DMG/ZIP artifacts without macOS updater metadata unless signed auto-update is explicitly enabled
- chore: bump version to 3.0.7

## Testing
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`
- [x] `pnpm run electron:package:ci`
- [x] `pnpm run electron:verify-mac-entitlements`
- [x] `YAP_REQUIRE_MAC_TRUSTED_SIGNING=1 pnpm run electron:verify-mac-entitlements || true` rejects the non-Developer-ID local signature
- [x] `git diff --check`
- [x] workflow YAML parse check
- [x] unsigned macOS release cleanup leaves only the manual `.dmg` and `.zip` artifacts

## Version Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* fix: harden in-app update install flow by @oobagi in https://github.com/oobagi/yap/pull/68
* fix: route unsigned macOS updates to GitHub Releases by @oobagi in this PR
* ci: publish unsigned macOS manual artifacts by @oobagi in this PR
* chore: bump version to 3.0.6 by @oobagi in https://github.com/oobagi/yap/pull/68
* chore: bump version to 3.0.7 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.5...v3.0.7
