### PR TITLE
Release v3.0.8

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -119,7 +119,9 @@ jobs:
 
       - name: Package Electron app
         working-directory: desktop
+        shell: bash
         env:
+          YAP_PUBLISH_MAC_AUTO_UPDATE: ${{ vars.YAP_PUBLISH_MAC_AUTO_UPDATE }}
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/v') && vars.YAP_PUBLISH_MAC_AUTO_UPDATE == 'true' && 'true' || 'false' }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -131,7 +133,18 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_KEYCHAIN: ${{ secrets.APPLE_KEYCHAIN }}
           APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
-        run: pnpm run electron:package:ci
+        run: |
+          if [[ -z "${CSC_LINK:-}" ]]; then
+            unset CSC_LINK CSC_KEY_PASSWORD
+          fi
+
+          if [[ "${YAP_PUBLISH_MAC_AUTO_UPDATE:-}" != "true" ]]; then
+            unset APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER
+            unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+            unset APPLE_KEYCHAIN APPLE_KEYCHAIN_PROFILE
+          fi
+
+          pnpm run electron:package:ci
 
       - name: Verify macOS entitlements
         if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.7"
+version = "3.0.8"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.7"
+version = "3.0.8"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",


### PR DESCRIPTION
## Summary
- ci: unset empty macOS signing and notarization environment variables before Electron Builder runs
- chore: bump version to 3.0.8

## Testing
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `CSC_LINK='' CSC_KEY_PASSWORD='' YAP_PUBLISH_MAC_AUTO_UPDATE='' CSC_IDENTITY_AUTO_DISCOVERY=false ... pnpm run electron:package:ci`
- [x] `pnpm run electron:verify-mac-entitlements`
- [x] `YAP_REQUIRE_MAC_TRUSTED_SIGNING=1 pnpm run electron:verify-mac-entitlements || true` rejects the ad-hoc local package
- [x] `git diff --check`
- [x] workflow YAML parse check
- [x] unsigned macOS release cleanup leaves only the manual `.dmg` and `.zip` artifacts

## Version Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* fix: harden in-app update install flow by @oobagi in https://github.com/oobagi/yap/pull/68
* fix: route unsigned macOS updates to GitHub Releases by @oobagi in https://github.com/oobagi/yap/pull/69
* ci: publish unsigned macOS manual artifacts by @oobagi in https://github.com/oobagi/yap/pull/69
* ci: unset empty macOS signing env by @oobagi in this PR
* chore: bump version to 3.0.6 by @oobagi in https://github.com/oobagi/yap/pull/68
* chore: bump version to 3.0.7 by @oobagi in https://github.com/oobagi/yap/pull/69
* chore: bump version to 3.0.8 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.5...v3.0.8
