### PR TITLE
Release v3.0.9

### DIFF
--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.8"
+version = "3.0.9"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/native-core/sidecar-overlay/Sources/OverlayLayout.swift
+++ b/desktop/native-core/sidecar-overlay/Sources/OverlayLayout.swift
@@ -38,4 +38,5 @@ enum OverlayLayout {
 
     static let hoverTooltipYOffset: CGFloat = -24
     static let hoverTooltipTransitionYOffset: CGFloat = 4
+    static let recordingTimerVisibleAfter: TimeInterval = 10
 }

--- a/desktop/native-core/sidecar-overlay/Sources/OverlayPanel.swift
+++ b/desktop/native-core/sidecar-overlay/Sources/OverlayPanel.swift
@@ -204,7 +204,7 @@ class OverlayPanel: NSPanel {
             overlayState.bandLevels = Array(repeating: 0, count: 11)
             overlayState.isHandsFree = false
             overlayState.isPaused = false
-            overlayState.handsFreeElapsed = elapsed
+            overlayState.recordingElapsed = elapsed
             if wasIdle {
                 alphaValue = 1
                 if !overlayState.alwaysVisible { slideIn() } else { showAtRest() }
@@ -224,7 +224,7 @@ class OverlayPanel: NSPanel {
             }
             overlayState.isHandsFree = handsFree
             overlayState.isPaused = paused
-            overlayState.handsFreeElapsed = elapsed
+            overlayState.recordingElapsed = elapsed
 
         case "processing":
             overlayState.isHandsFree = false
@@ -260,7 +260,7 @@ class OverlayPanel: NSPanel {
         overlayState.audioLevel = level
         overlayState.bandLevels = bars
         if overlayState.mode == .recording {
-            overlayState.handsFreeElapsed = elapsed
+            overlayState.recordingElapsed = elapsed
         }
         updateButtonTargets()
     }
@@ -545,7 +545,7 @@ class OverlayState: ObservableObject {
     @Published var isHovering: Bool = false
     @Published var gradientEnabled: Bool = true
     @Published var alwaysVisible: Bool = true
-    @Published var handsFreeElapsed: TimeInterval = 0
+    @Published var recordingElapsed: TimeInterval = 0
     var onPermissionAction: (() -> Void)?
     var onPauseResume: (() -> Void)?
     var onStop: (() -> Void)?
@@ -623,8 +623,8 @@ struct OverlayView: View {
                             .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .bottom)))
                     }
 
-                    if state.mode == .recording && state.isHandsFree {
-                        Text(formatElapsed(state.handsFreeElapsed))
+                    if showRecordingTimer {
+                        Text(formatElapsed(state.recordingElapsed))
                             .font(.system(size: 11, weight: .medium, design: .monospaced))
                             .foregroundColor(.white.opacity(0.5))
                             .fixedSize()
@@ -691,6 +691,7 @@ struct OverlayView: View {
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: state.onboardingStep)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: state.mode)
                 .animation(.spring(response: 0.45, dampingFraction: 0.7), value: state.mode == .recording && state.isHandsFree)
+                .animation(.easeOut(duration: 0.35), value: showRecordingTimer)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: stackYOffset)
 
                 Spacer().frame(height: OverlayLayout.bottomSpacerHeight)
@@ -708,6 +709,10 @@ struct OverlayView: View {
     private var pillScale: CGFloat {
         if isExpanded { return 0.82 }
         return state.isHovering ? 0.58 : 0.5
+    }
+
+    private var showRecordingTimer: Bool {
+        state.mode == .recording && state.recordingElapsed >= OverlayLayout.recordingTimerVisibleAfter
     }
 
     private func formatElapsed(_ seconds: TimeInterval) -> String {

--- a/desktop/native-core/src/dictation.rs
+++ b/desktop/native-core/src/dictation.rs
@@ -67,6 +67,10 @@ static RUNTIME: once_cell::sync::Lazy<Mutex<RuntimeState>> =
     once_cell::sync::Lazy::new(|| Mutex::new(RuntimeState::Idle));
 static RECORDING_STARTED_AT: once_cell::sync::Lazy<Mutex<Option<Instant>>> =
     once_cell::sync::Lazy::new(|| Mutex::new(None));
+static RECORDING_PAUSED_AT: once_cell::sync::Lazy<Mutex<Option<Instant>>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(None));
+static RECORDING_PAUSED_DURATION: once_cell::sync::Lazy<Mutex<Duration>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(Duration::ZERO));
 static PEAK_LEVEL: once_cell::sync::Lazy<Mutex<f32>> =
     once_cell::sync::Lazy::new(|| Mutex::new(0.0));
 static ONBOARDING_STEP: once_cell::sync::Lazy<Mutex<Option<OnboardingStep>>> =
@@ -172,9 +176,7 @@ fn reset_active_runtime() {
         let _ = audio::stop_recording();
         audio_ducking::end();
     }
-    if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
-        *started_at = None;
-    }
+    clear_recording_clock();
     if let Ok(mut peak) = PEAK_LEVEL.lock() {
         *peak = 0.0;
     }
@@ -223,9 +225,7 @@ fn begin_press_to_record() -> bool {
     if let Ok(mut peak) = PEAK_LEVEL.lock() {
         *peak = 0.0;
     }
-    if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
-        *started_at = Some(Instant::now());
-    }
+    start_recording_clock();
     if let Ok(mut active_hands_free) = HANDS_FREE_RECORDING.lock() {
         *active_hands_free = false;
     }
@@ -257,9 +257,7 @@ fn begin_hands_free_recording(ignore_pending_key_up: bool) -> bool {
     }
 
     let generation = next_recording_generation();
-    if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
-        *started_at = Some(Instant::now());
-    }
+    start_recording_clock();
     if let Ok(mut active_hands_free) = HANDS_FREE_RECORDING.lock() {
         *active_hands_free = true;
     }
@@ -292,9 +290,7 @@ fn start_recording_for_generation(generation: u64, hands_free: bool) -> bool {
 
     match audio::start_recording((!device.is_empty()).then_some(device)) {
         Ok(_) => {
-            if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
-                *started_at = Some(Instant::now());
-            }
+            start_recording_clock();
             if let Ok(mut active_hands_free) = HANDS_FREE_RECORDING.lock() {
                 *active_hands_free = hands_free;
             }
@@ -349,14 +345,9 @@ fn on_key_up() {
         return;
     }
 
-    let started_at = RECORDING_STARTED_AT.lock().ok().and_then(|guard| *guard);
     let peak = current_peak_level();
-    if started_at.is_some_and(|started| started.elapsed().as_millis() < 500)
-        && peak < SILENCE_PEAK_THRESHOLD
-    {
-        if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
-            *started_at = None;
-        }
+    if recording_elapsed_duration().as_millis() < 500 && peak < SILENCE_PEAK_THRESHOLD {
+        clear_recording_clock();
         let _ = audio::stop_recording();
         audio_ducking::end();
         begin_tap_pending("too short / quiet", false);
@@ -420,10 +411,12 @@ fn on_overlay_pause() {
     match state() {
         RuntimeState::Recording if is_hands_free_recording() => {
             audio::pause_recording();
+            pause_recording_clock();
             set_state(RuntimeState::Paused);
         }
         RuntimeState::Paused => {
             audio::resume_recording();
+            resume_recording_clock();
             set_state(RuntimeState::Recording);
         }
         _ => {}
@@ -550,9 +543,7 @@ fn finalize_onboarding() {
 
 fn stop_and_process() {
     set_state(RuntimeState::Processing);
-    if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
-        *started_at = None;
-    }
+    clear_recording_clock();
     let wav_path = match audio::stop_recording() {
         Ok(path) => path,
         Err(error) => {
@@ -786,6 +777,12 @@ fn set_state(next: RuntimeState) {
         }
         if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
             *started_at = None;
+        }
+        if let Ok(mut paused_at) = RECORDING_PAUSED_AT.lock() {
+            *paused_at = None;
+        }
+        if let Ok(mut paused_duration) = RECORDING_PAUSED_DURATION.lock() {
+            *paused_duration = Duration::ZERO;
         }
         if let Ok(mut peak) = PEAK_LEVEL.lock() {
             *peak = 0.0;
@@ -1179,12 +1176,73 @@ fn emit_overlay_permission(_title: &str, _message: &str, _action_label: &str, _v
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn recording_elapsed_seconds() -> f64 {
+    recording_elapsed_duration().as_secs_f64()
+}
+
+fn start_recording_clock() {
+    if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
+        *started_at = Some(Instant::now());
+    }
+    if let Ok(mut paused_at) = RECORDING_PAUSED_AT.lock() {
+        *paused_at = None;
+    }
+    if let Ok(mut paused_duration) = RECORDING_PAUSED_DURATION.lock() {
+        *paused_duration = Duration::ZERO;
+    }
+}
+
+fn clear_recording_clock() {
+    if let Ok(mut started_at) = RECORDING_STARTED_AT.lock() {
+        *started_at = None;
+    }
+    if let Ok(mut paused_at) = RECORDING_PAUSED_AT.lock() {
+        *paused_at = None;
+    }
+    if let Ok(mut paused_duration) = RECORDING_PAUSED_DURATION.lock() {
+        *paused_duration = Duration::ZERO;
+    }
+}
+
+fn pause_recording_clock() {
+    if let Ok(mut paused_at) = RECORDING_PAUSED_AT.lock() {
+        if paused_at.is_none() {
+            *paused_at = Some(Instant::now());
+        }
+    }
+}
+
+fn resume_recording_clock() {
+    let paused_at = RECORDING_PAUSED_AT
+        .lock()
+        .ok()
+        .and_then(|mut paused_at| paused_at.take());
+    if let Some(paused_at) = paused_at {
+        if let Ok(mut paused_duration) = RECORDING_PAUSED_DURATION.lock() {
+            *paused_duration += paused_at.elapsed();
+        }
+    }
+}
+
+fn recording_elapsed_duration() -> Duration {
     RECORDING_STARTED_AT
         .lock()
         .ok()
         .and_then(|started_at| *started_at)
-        .map(|started_at| started_at.elapsed().as_secs_f64())
-        .unwrap_or(0.0)
+        .map(|started_at| {
+            let mut paused_duration = RECORDING_PAUSED_DURATION
+                .lock()
+                .map(|duration| *duration)
+                .unwrap_or(Duration::ZERO);
+            if let Some(paused_at) = RECORDING_PAUSED_AT
+                .lock()
+                .ok()
+                .and_then(|paused_at| *paused_at)
+            {
+                paused_duration += paused_at.elapsed();
+            }
+            started_at.elapsed().saturating_sub(paused_duration)
+        })
+        .unwrap_or(Duration::ZERO)
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]

--- a/desktop/native-core/src/win_overlay.rs
+++ b/desktop/native-core/src/win_overlay.rs
@@ -50,6 +50,7 @@ const HOVER_TOOLTIP_OFFSET_Y: f32 = -24.0;
 const HOVER_TOOLTIP_TRANSITION_Y: f32 = 4.0;
 const CARD_GAP_Y: f32 = 50.0;
 const TIMER_GAP_Y: f32 = 40.0;
+const TIMER_VISIBLE_AFTER_SECONDS: f64 = 10.0;
 const EXPANDED_PILL_SCALE: f32 = 0.82;
 const HOVER_PILL_SCALE: f32 = 0.58;
 const IDLE_PILL_SCALE: f32 = 0.5;
@@ -238,6 +239,7 @@ struct AnimState {
     content_width: Spring,        // Pill content width, including controls
     audio_bounce: Spring,         // Recording scale pulse driven by audio level
     hands_free_progress: Spring,  // 0→1 for pause/stop control entrance
+    timer_opacity: Spring,        // 0→1 for delayed recording timer fade-in
     error_timer: Option<Instant>, // When error was shown
     shake_progress: f32,          // 0→1 for no-speech shake
     shake_active: bool,
@@ -263,6 +265,7 @@ impl AnimState {
             content_width: Spring::new(IDLE_CONTENT_W, 180.0, 22.0),
             audio_bounce: Spring::new(1.0, 160.0, 24.0),
             hands_free_progress: Spring::new(0.0, 180.0, 22.0),
+            timer_opacity: Spring::new(0.0, 180.0, 24.0),
             error_timer: None,
             shake_progress: 0.0,
             shake_active: false,
@@ -328,6 +331,12 @@ impl AnimState {
                 0.0
             },
         );
+        self.timer_opacity
+            .set_target(if show_recording_timer(state) {
+                1.0
+            } else {
+                0.0
+            });
 
         let base_scale = if is_expanded {
             EXPANDED_PILL_SCALE
@@ -455,6 +464,7 @@ impl AnimState {
         self.content_width.tick(dt);
         self.audio_bounce.tick(dt);
         self.hands_free_progress.tick(dt);
+        self.timer_opacity.tick(dt);
     }
 
     fn needs_animation(&self, state: &OverlayState) -> bool {
@@ -469,6 +479,7 @@ impl AnimState {
             || !self.content_width.is_settled()
             || !self.audio_bounce.is_settled()
             || !self.hands_free_progress.is_settled()
+            || !self.timer_opacity.is_settled()
             || !self.pill_opacity.is_settled()
             || self.shake_active
             || self.bar_springs.iter().any(|s| !s.is_settled())
@@ -1358,17 +1369,19 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
         }
     }
 
-    // -- Elapsed time (above pill, hands-free) --
-    if state.mode == "recording" && state.hands_free {
+    // -- Elapsed time (above pill, after the first 10s of recording) --
+    let timer_opacity = anim.timer_opacity.val();
+    if timer_opacity > 0.01 {
         if let Some(ref fr) = font {
             let elapsed_text = format_elapsed(state.elapsed);
+            let alpha = (128.0 * timer_opacity).round().clamp(0.0, 128.0) as u8;
             fr.render_centered(
                 &mut pixmap,
                 &elapsed_text,
                 cx,
-                pill_cy - TIMER_GAP_Y,
+                pill_cy - TIMER_GAP_Y + (1.0 - timer_opacity) * 12.0,
                 11.0,
-                [255, 255, 255, 128],
+                [255, 255, 255, alpha],
             );
         }
     }
@@ -2065,6 +2078,10 @@ fn onboarding_card_text(step: &OnboardingStep, hotkey_label: &str) -> String {
 fn format_elapsed(seconds: f64) -> String {
     let s = seconds as u64;
     format!("{}:{:02}", s / 60, s % 60)
+}
+
+fn show_recording_timer(state: &OverlayState) -> bool {
+    state.mode == "recording" && state.elapsed >= TIMER_VISIBLE_AFTER_SECONDS
 }
 
 // ---------------------------------------------------------------------------

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",


### PR DESCRIPTION
## Summary
- fix: restore the recording timer for every recording mode after 10 seconds
- fix: freeze recording elapsed time while hands-free recording is paused
- chore: bump version to 3.0.9

## Testing
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`
- [x] `git diff --check`

## Version Bump Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* fix: restore recording timer behavior by @oobagi in this PR
* chore: bump version to 3.0.9 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.8...v3.0.9
