### PR TITLE
Release v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/macOS-13%2B-blue" alt="macOS 13+">
+  <img src="https://img.shields.io/badge/macOS-26%2B-blue" alt="macOS 26+">
   <img src="https://img.shields.io/badge/Windows-10%2B-blue" alt="Windows 10+">
   <img src="https://img.shields.io/badge/Electron-42-47848f" alt="Electron 42">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT">
@@ -39,7 +39,7 @@ https://github.com/oobagi/yap/releases/latest
 
 - Global push-to-talk dictation that pastes into the active app.
 - Hands-free recording from the hotkey or floating pill.
-- Local macOS transcription or cloud transcription with Gemini, OpenAI, Deepgram, and ElevenLabs.
+- Local macOS 26+ SpeechAnalyzer transcription or cloud transcription with Gemini, OpenAI, Deepgram, and ElevenLabs.
 - Optional cleanup styles for casual, formatted, or professional text.
 - Local transcript history and in-app update checks.
 
@@ -47,7 +47,7 @@ https://github.com/oobagi/yap/releases/latest
 
 Open the tray/menu bar icon, choose **Settings**, then pick a transcription provider. Windows does not have the macOS on-device option, so choose one of the API providers below.
 
-- On-device transcription (macOS only, no API key)
+- On-device transcription (macOS 26+ only, no API key)
 - [Gemini](https://ai.google.dev/gemini-api/docs/api-key)
 - [OpenAI](https://platform.openai.com/api-keys)
 - [Deepgram](https://developers.deepgram.com/docs/create-additional-api-keys)

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -28,11 +28,13 @@ extraResources:
 mac:
   category: public.app-category.productivity
   icon: native-core/icons/icon.icns
+  minimumSystemVersion: "26.0"
   entitlements: electron/entitlements.mac.plist
   entitlementsInherit: electron/entitlements.mac.inherit.plist
   extendInfo:
+    LSMinimumSystemVersion: "26.0"
     NSMicrophoneUsageDescription: Yap records your voice so it can transcribe and paste what you say.
-    NSSpeechRecognitionUsageDescription: Yap uses speech recognition to transcribe audio locally when available.
+    NSSpeechRecognitionUsageDescription: Yap uses Apple SpeechAnalyzer to transcribe audio locally on macOS 26 or newer.
   target:
     - dmg
     - zip

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3339,7 +3339,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "3.0.9"
+version = "4.0.0"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -160,15 +160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2 0.6.4",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +918,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb69199826926eb864697bddd27f73d9fddcffc004f5733131e15b465e30642"
 dependencies = [
- "block2 0.4.0",
+ "block2",
  "objc2 0.5.2",
 ]
 
@@ -3352,7 +3343,6 @@ version = "3.0.9"
 dependencies = [
  "arboard",
  "base64",
- "block2 0.6.2",
  "chrono",
  "core-graphics 0.24.0",
  "cpal",
@@ -3361,7 +3351,6 @@ dependencies = [
  "enigo",
  "fontdue",
  "hound",
- "objc2 0.6.4",
  "once_cell",
  "reqwest",
  "rodio",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "3.0.9"
+version = "4.0.0"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -54,8 +54,6 @@ fontdue = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.24"
-objc2 = "0.6"
-block2 = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # 2D rendering for native overlay pill

--- a/desktop/native-core/build.rs
+++ b/desktop/native-core/build.rs
@@ -21,9 +21,8 @@ fn main() {
         }
     }
 
-    // Link the Speech framework on macOS for SFSpeechRecognizer
+    // Link macOS frameworks used by native OS integration.
     if target_os == "macos" {
-        println!("cargo:rustc-link-lib=framework=Speech");
         println!("cargo:rustc-link-lib=framework=ApplicationServices");
     }
 }

--- a/desktop/native-core/sidecar-overlay/Package.swift
+++ b/desktop/native-core/sidecar-overlay/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(
     name: "yap-overlay",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v26)],
     products: [
         .executable(name: "yap-overlay", targets: ["yap-overlay"]),
         .executable(name: "yap-speech", targets: ["yap-speech"]),

--- a/desktop/native-core/sidecar-overlay/SpeechSources/main.swift
+++ b/desktop/native-core/sidecar-overlay/SpeechSources/main.swift
@@ -1,122 +1,213 @@
+import AVFoundation
 import Foundation
 import Speech
 
-func fail(_ message: String, code: Int32 = 1) -> Never {
+enum HelperError: Error, CustomStringConvertible {
+    case message(String)
+    case timeout(TimeInterval)
+
+    var description: String {
+        switch self {
+        case .message(let message):
+            return message
+        case .timeout(let seconds):
+            return "SpeechAnalyzer timed out after \(String(format: "%.1f", seconds)) seconds"
+        }
+    }
+}
+
+func log(_ message: String) {
     FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+func fail(_ message: String, code: Int32 = 1) -> Never {
+    log(message)
     exit(code)
 }
 
-guard CommandLine.arguments.count >= 3 else {
-    fail("usage: yap-speech <wav-path> <locale> [timeout-seconds]")
+func withTimeout<T: Sendable>(
+    seconds: TimeInterval,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            let nanoseconds = UInt64(max(seconds, 0.1) * 1_000_000_000)
+            try await Task.sleep(nanoseconds: nanoseconds)
+            throw HelperError.timeout(seconds)
+        }
+
+        guard let result = try await group.next() else {
+            throw HelperError.message("SpeechAnalyzer task ended without a result")
+        }
+        group.cancelAll()
+        return result
+    }
 }
 
-let audioURL = URL(fileURLWithPath: CommandLine.arguments[1])
-let localeID = CommandLine.arguments[2]
-let timeoutSeconds = CommandLine.arguments.count >= 4
-    ? Double(CommandLine.arguments[3]) ?? 30
-    : 30
-
-guard FileManager.default.fileExists(atPath: audioURL.path) else {
-    fail("audio file not found: \(audioURL.path)")
-}
-
-func authorizationLabel(_ status: SFSpeechRecognizerAuthorizationStatus) -> String {
+func statusLabel(_ status: AssetInventory.Status) -> String {
     switch status {
-    case .notDetermined:
-        return "notDetermined"
-    case .denied:
-        return "denied"
-    case .restricted:
-        return "restricted"
-    case .authorized:
-        return "authorized"
+    case .unsupported:
+        return "unsupported"
+    case .supported:
+        return "supported"
+    case .downloading:
+        return "downloading"
+    case .installed:
+        return "installed"
     @unknown default:
         return "unknown"
     }
 }
 
-func ensureAuthorized() -> SFSpeechRecognizerAuthorizationStatus {
-    let status = SFSpeechRecognizer.authorizationStatus()
-    if status != .notDetermined {
-        return status
+func ensureSpeechAssets(
+    for transcriber: SpeechTranscriber,
+    localeIdentifier: String,
+    timeoutSeconds: TimeInterval
+) async throws {
+    let status = await AssetInventory.status(forModules: [transcriber])
+    log("asset_status=\(statusLabel(status))")
+
+    switch status {
+    case .installed:
+        return
+    case .unsupported:
+        throw HelperError.message(
+            "SpeechAnalyzer assets are unsupported for locale: \(localeIdentifier)"
+        )
+    case .downloading:
+        throw HelperError.message(
+            "SpeechAnalyzer speech assets for \(localeIdentifier) are still downloading. Try again when macOS finishes installing on-device speech assets."
+        )
+    case .supported:
+        guard let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) else {
+            throw HelperError.message(
+                "SpeechAnalyzer speech assets for \(localeIdentifier) are not installed and no installation request is available."
+            )
+        }
+
+        log("asset_status=installing")
+        try await withTimeout(seconds: timeoutSeconds) {
+            try await request.downloadAndInstall()
+        }
+
+        let installedStatus = await AssetInventory.status(forModules: [transcriber])
+        log("asset_status=\(statusLabel(installedStatus))")
+        guard installedStatus == .installed else {
+            throw HelperError.message(
+                "SpeechAnalyzer speech assets for \(localeIdentifier) are installing or unavailable. Current status: \(statusLabel(installedStatus))."
+            )
+        }
+    @unknown default:
+        throw HelperError.message(
+            "SpeechAnalyzer speech asset status is unknown for locale: \(localeIdentifier)"
+        )
+    }
+}
+
+func transcribe(
+    audioURL: URL,
+    localeIdentifier: String,
+    timeoutSeconds: TimeInterval
+) async throws -> String {
+    guard SpeechTranscriber.isAvailable else {
+        throw HelperError.message("SpeechAnalyzer transcription is unavailable on this Mac")
     }
 
-    var nextStatus = status
-    let semaphore = DispatchSemaphore(value: 0)
-    SFSpeechRecognizer.requestAuthorization { requestedStatus in
-        nextStatus = requestedStatus
-        semaphore.signal()
+    let requestedLocale = Locale(identifier: localeIdentifier)
+    guard let supportedLocale = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale) else {
+        throw HelperError.message("SpeechAnalyzer does not support locale: \(localeIdentifier)")
     }
 
-    _ = semaphore.wait(timeout: .now() + 30)
-    return nextStatus
-}
+    let file = try AVAudioFile(forReading: audioURL)
+    let format = file.processingFormat
+    let durationSeconds = Double(file.length) / format.sampleRate
+    log(
+        "audio_file=\(audioURL.path) locale=\(supportedLocale.identifier(.bcp47)) duration=\(String(format: "%.3f", durationSeconds))s sample_rate=\(String(format: "%.0f", format.sampleRate)) channels=\(format.channelCount)"
+    )
 
-let authorization = ensureAuthorized()
-FileHandle.standardError.write(Data("authorization=\(authorizationLabel(authorization))\n".utf8))
-guard authorization == .authorized else {
-    fail("speech recognition permission is \(authorizationLabel(authorization))")
-}
+    let transcriber = SpeechTranscriber(locale: supportedLocale, preset: .transcription)
+    try await ensureSpeechAssets(
+        for: transcriber,
+        localeIdentifier: supportedLocale.identifier(.bcp47),
+        timeoutSeconds: timeoutSeconds
+    )
 
-guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: localeID)) else {
-    fail("speech recognizer unavailable for locale: \(localeID)")
-}
+    let analyzer = SpeechAnalyzer(modules: [transcriber])
+    let resultTask = Task {
+        var parts: [String] = []
+        var finalCount = 0
 
-guard recognizer.isAvailable else {
-    fail("speech recognizer is not available")
-}
+        for try await result in transcriber.results {
+            guard result.isFinal else {
+                continue
+            }
 
-if #available(macOS 10.15, *) {
-    guard recognizer.supportsOnDeviceRecognition else {
-        fail("on-device speech recognition is not available for locale: \(localeID)")
+            let text = String(result.text.characters)
+            finalCount += 1
+            log("final_result index=\(finalCount) len=\(text.trimmingCharacters(in: .whitespacesAndNewlines).count)")
+            parts.append(text)
+        }
+
+        return parts.joined()
+    }
+
+    do {
+        let lastSample = try await analyzer.analyzeSequence(from: file)
+        if lastSample != nil {
+            try await analyzer.finalizeAndFinishThroughEndOfInput()
+        } else {
+            await analyzer.cancelAndFinishNow()
+        }
+
+        let transcript = try await resultTask.value
+        log("completed len=\(transcript.trimmingCharacters(in: .whitespacesAndNewlines).count)")
+        return transcript
+    } catch {
+        resultTask.cancel()
+        await analyzer.cancelAndFinishNow()
+        throw error
     }
 }
 
-let request = SFSpeechURLRecognitionRequest(url: audioURL)
-request.shouldReportPartialResults = true
-if #available(macOS 10.15, *) {
-    request.requiresOnDeviceRecognition = true
-}
+@main
+struct YapSpeech {
+    static func main() async {
+        guard CommandLine.arguments.count >= 3 else {
+            fail("usage: yap-speech <wav-path> <locale> [timeout-seconds]")
+        }
 
-var latestText = ""
-var finalText: String?
-var failure: String?
-var completed = false
+        let audioURL = URL(fileURLWithPath: CommandLine.arguments[1])
+        let localeIdentifier = CommandLine.arguments[2]
+        let timeoutSeconds = CommandLine.arguments.count >= 4
+            ? Double(CommandLine.arguments[3]) ?? 30
+            : 30
 
-let task = recognizer.recognitionTask(with: request) { result, error in
-    if let result {
-        latestText = result.bestTranscription.formattedString
-        if result.isFinal {
-            finalText = latestText
-            completed = true
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            fail("audio file not found: \(audioURL.path)")
+        }
+
+        do {
+            let transcript = try await withTimeout(seconds: timeoutSeconds) {
+                try await transcribe(
+                    audioURL: audioURL,
+                    localeIdentifier: localeIdentifier,
+                    timeoutSeconds: timeoutSeconds
+                )
+            }
+            print(transcript)
+            exit(0)
+        } catch let error as HelperError {
+            switch error {
+            case .timeout:
+                fail(error.description, code: 2)
+            case .message:
+                fail(error.description)
+            }
+        } catch {
+            fail(error.localizedDescription)
         }
     }
-
-    if let error {
-        failure = error.localizedDescription
-        completed = true
-    }
 }
-
-let deadline = Date().addingTimeInterval(timeoutSeconds)
-while !completed && Date() < deadline {
-    RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.05))
-}
-
-task.cancel()
-
-if let finalText {
-    print(finalText)
-    exit(0)
-}
-
-if !latestText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-    print(latestText)
-    exit(0)
-}
-
-if let failure {
-    fail(failure)
-}
-
-fail("speech recognition timed out", code: 2)

--- a/desktop/native-core/src/audio.rs
+++ b/desktop/native-core/src/audio.rs
@@ -91,6 +91,13 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
         stream_config.buffer_size
     ));
 
+    if RECORDING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err("recording already in progress".into());
+    }
+
     let wav_path = std::env::temp_dir().join("yap_recording.wav");
 
     let spec = WavSpec {
@@ -100,8 +107,13 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
         sample_format: SampleFormat::Int,
     };
 
-    let writer = WavWriter::create(&wav_path, spec)
-        .map_err(|e| format!("failed to create WAV file: {e}"))?;
+    let writer = match WavWriter::create(&wav_path, spec) {
+        Ok(writer) => writer,
+        Err(e) => {
+            RECORDING.store(false, Ordering::SeqCst);
+            return Err(format!("failed to create WAV file: {e}"));
+        }
+    };
 
     // Store the writer and path
     if let Ok(mut w) = WAV_WRITER.lock() {
@@ -120,7 +132,6 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
     }
     STOP_FLAG.store(false, Ordering::SeqCst);
     PAUSED.store(false, Ordering::SeqCst);
-    RECORDING.store(true, Ordering::SeqCst);
 
     let writer_ref = WAV_WRITER.clone();
     let levels_ref = CURRENT_LEVELS.clone();
@@ -129,7 +140,7 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
 
     // Build the stream on a dedicated thread (cpal::Stream is !Send,
     // so it must live on the thread that created it).
-    let thread = std::thread::Builder::new()
+    let thread = match std::thread::Builder::new()
         .name("yap-audio".into())
         .spawn(move || {
             let err_fn = |err: cpal::StreamError| {
@@ -248,8 +259,13 @@ pub fn start_recording(device_name: Option<&str>) -> Result<PathBuf, String> {
             drop(stream);
 
             RECORDING.store(false, Ordering::SeqCst);
-        })
-        .map_err(|e| format!("failed to spawn audio thread: {e}"))?;
+        }) {
+        Ok(thread) => thread,
+        Err(e) => {
+            cleanup_failed_start();
+            return Err(format!("failed to spawn audio thread: {e}"));
+        }
+    };
 
     match ready_rx.recv_timeout(Duration::from_secs(2)) {
         Ok(Ok(())) => {}
@@ -392,12 +408,13 @@ fn process_audio_callback(
         })
         .collect();
 
-    // Write to WAV if not paused
-    if !PAUSED.load(Ordering::Relaxed) && !STOP_FLAG.load(Ordering::Relaxed) {
+    // Write the whole callback that was already delivered before stop was
+    // observed, so key release does not truncate the tail mid-buffer.
+    if !PAUSED.load(Ordering::Relaxed) {
         if let Ok(mut guard) = writer.lock() {
             if let Some(ref mut w) = *guard {
                 for &sample in &mono_samples {
-                    if PAUSED.load(Ordering::Relaxed) || STOP_FLAG.load(Ordering::Relaxed) {
+                    if PAUSED.load(Ordering::Relaxed) {
                         break;
                     }
                     let s16 =
@@ -462,6 +479,8 @@ pub fn stop_recording() -> Result<PathBuf, String> {
         return Err("no active recording session".into());
     }
 
+    log_audio("stop requested");
+
     // Signal the recording thread to stop
     STOP_FLAG.store(true, Ordering::SeqCst);
 
@@ -472,14 +491,20 @@ pub fn stop_recording() -> Result<PathBuf, String> {
         }
         std::thread::sleep(std::time::Duration::from_millis(5));
     }
+    if RECORDING.load(Ordering::SeqCst) {
+        log_audio("audio thread did not acknowledge stop before WAV finalization");
+    }
 
     // Finalize the WAV writer
+    log_audio("finalizing WAV writer");
     if let Ok(mut guard) = WAV_WRITER.lock() {
         if let Some(writer) = guard.take() {
             writer
                 .finalize()
                 .map_err(|e| format!("failed to finalize WAV: {e}"))?;
         }
+    } else {
+        return Err("failed to lock WAV writer for finalization".to_string());
     }
 
     let path = WAV_PATH
@@ -488,7 +513,37 @@ pub fn stop_recording() -> Result<PathBuf, String> {
         .and_then(|p| p.clone())
         .ok_or_else(|| "no WAV path available".to_string())?;
 
+    log_finalized_wav(&path);
+
     Ok(path)
+}
+
+fn log_finalized_wav(path: &PathBuf) {
+    let size = std::fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    match hound::WavReader::open(path) {
+        Ok(reader) => {
+            let spec = reader.spec();
+            if spec.sample_rate > 0 && spec.channels > 0 {
+                let frames = reader.duration() as f64 / spec.channels as f64;
+                let duration = frames / spec.sample_rate as f64;
+                log_audio(&format!(
+                    "finalized WAV path={path:?} size={size} duration={duration:.3}s sample_rate={} channels={} bits={}",
+                    spec.sample_rate, spec.channels, spec.bits_per_sample
+                ));
+            } else {
+                log_audio(&format!(
+                    "finalized WAV path={path:?} size={size} invalid sample metadata"
+                ));
+            }
+        }
+        Err(error) => {
+            log_audio(&format!(
+                "finalized WAV path={path:?} size={size} metadata_error={error}"
+            ));
+        }
+    }
 }
 
 /// Pause audio capture (hands-free mode). Engine keeps running for levels.

--- a/desktop/native-core/src/speech.rs
+++ b/desktop/native-core/src/speech.rs
@@ -1,6 +1,6 @@
 //! On-device speech recognition via platform-native APIs.
 //!
-//! macOS: SFSpeechRecognizer (Speech framework)
+//! macOS: SpeechAnalyzer helper process (macOS 26+)
 //! Windows: not yet implemented (returns error)
 //!
 //! Entry point:
@@ -9,195 +9,28 @@
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
-// macOS implementation — SFSpeechRecognizer via objc2 FFI
+// macOS implementation — SpeechAnalyzer helper
 // ---------------------------------------------------------------------------
 
 #[cfg(target_os = "macos")]
 mod platform {
     use crate::log;
 
-    use std::ffi::{c_char, CStr, CString};
     use std::path::{Path, PathBuf};
     use std::process::Command;
-    use std::sync::{mpsc, Arc, Mutex};
     use std::time::Duration;
 
-    use block2::RcBlock;
-    use objc2::msg_send;
-    use objc2::runtime::{AnyClass, AnyObject};
-
-    const AUTH_NOT_DETERMINED: isize = 0;
-    const AUTH_DENIED: isize = 1;
-    const AUTH_RESTRICTED: isize = 2;
-    const AUTH_AUTHORIZED: isize = 3;
-
-    /// Transcribe audio using on-device SFSpeechRecognizer.
+    /// Transcribe audio using Apple's SpeechAnalyzer helper.
     ///
     /// `locale` should be a BCP 47 string like "en-US".
     /// Returns the transcribed text, or an error.
     pub fn transcribe(audio_path: &Path, locale: &str) -> Result<String, String> {
-        let recognition_timeout = recognition_timeout(audio_path);
-        if let Some(helper) = speech_helper_path() {
-            return transcribe_with_helper(&helper, audio_path, locale, recognition_timeout);
-        }
-        log::info("Speech: Swift helper not found; falling back to Rust Speech bridge");
+        let timeout = recognition_timeout(audio_path);
+        let helper = speech_helper_path().ok_or_else(|| {
+            "SpeechAnalyzer helper not found. Rebuild the macOS sidecar with `pnpm run electron:build-sidecar`.".to_string()
+        })?;
 
-        let path_str = audio_path
-            .to_str()
-            .ok_or_else(|| "invalid audio path".to_string())?;
-        let path_cstr = CString::new(path_str).map_err(|e| format!("path encoding error: {e}"))?;
-        let locale_cstr =
-            CString::new(locale).map_err(|e| format!("locale encoding error: {e}"))?;
-
-        let (tx, rx) = mpsc::channel::<Result<String, String>>();
-        let latest_transcription = Arc::new(Mutex::new(String::new()));
-        log::info(&format!(
-            "Speech: starting on-device recognition path={path_str:?} locale={locale} timeout={recognition_timeout:?}"
-        ));
-
-        let recognizer_cls = AnyClass::get(c"SFSpeechRecognizer")
-            .ok_or("SFSpeechRecognizer not found — is the Speech framework available?")?;
-
-        unsafe {
-            ensure_speech_authorized(recognizer_cls)?;
-
-            // -- Create autorelease pool --
-            let pool_cls =
-                AnyClass::get(c"NSAutoreleasePool").ok_or("NSAutoreleasePool not found")?;
-            let pool: *mut AnyObject = msg_send![pool_cls, new];
-
-            // -- Create NSString helpers --
-            let ns_str_cls = AnyClass::get(c"NSString").ok_or("NSString not found")?;
-            let path_ns: *mut AnyObject =
-                msg_send![ns_str_cls, stringWithUTF8String: path_cstr.as_ptr()];
-            let locale_ns: *mut AnyObject =
-                msg_send![ns_str_cls, stringWithUTF8String: locale_cstr.as_ptr()];
-
-            // -- Create NSURL from file path --
-            let url_cls = AnyClass::get(c"NSURL").ok_or("NSURL not found")?;
-            let url: *mut AnyObject = msg_send![url_cls, fileURLWithPath: path_ns];
-
-            // -- Create NSLocale --
-            let locale_cls = AnyClass::get(c"NSLocale").ok_or("NSLocale not found")?;
-            let ns_locale: *mut AnyObject =
-                msg_send![locale_cls, localeWithLocaleIdentifier: locale_ns];
-
-            // -- Create SFSpeechRecognizer with locale --
-            let recognizer: *mut AnyObject = msg_send![recognizer_cls, alloc];
-            let recognizer: *mut AnyObject = msg_send![recognizer, initWithLocale: ns_locale];
-
-            if recognizer.is_null() {
-                let _: () = msg_send![pool, drain];
-                return Err(format!(
-                    "SFSpeechRecognizer not available for locale: {locale}"
-                ));
-            }
-
-            // Check availability
-            let available: bool = msg_send![recognizer, isAvailable];
-            if !available {
-                let _: () = msg_send![pool, drain];
-                return Err("SFSpeechRecognizer is not available on this device".to_string());
-            }
-
-            // -- Create SFSpeechURLRecognitionRequest --
-            let request_cls = AnyClass::get(c"SFSpeechURLRecognitionRequest")
-                .ok_or("SFSpeechURLRecognitionRequest not found")?;
-            let request: *mut AnyObject = msg_send![request_cls, alloc];
-            let request: *mut AnyObject = msg_send![request, initWithURL: url];
-            let _: () = msg_send![request, setShouldReportPartialResults: true];
-            let _: () = msg_send![request, setRequiresOnDeviceRecognition: true];
-
-            // -- Build the result handler block --
-            // Called by the Speech framework with partial/final results.
-            // Keep the latest partial result because macOS can delay or skip a
-            // final callback long enough to make short dictations feel broken.
-            let latest_for_handler = Arc::clone(&latest_transcription);
-            let block = RcBlock::new(move |result: *mut AnyObject, error: *mut AnyObject| {
-                // Error with no result → terminal failure
-                if !error.is_null() && result.is_null() {
-                    let desc: *mut AnyObject = msg_send![error, localizedDescription];
-                    if !desc.is_null() {
-                        let cstr: *const c_char = msg_send![desc, UTF8String];
-                        if !cstr.is_null() {
-                            let err_str = CStr::from_ptr(cstr).to_string_lossy().to_string();
-                            let _ = tx.send(Err(err_str));
-                            return;
-                        }
-                    }
-                    let _ = tx.send(Err("Speech recognition error".to_string()));
-                    return;
-                }
-
-                if !result.is_null() {
-                    let transcription: *mut AnyObject = msg_send![result, bestTranscription];
-                    if !transcription.is_null() {
-                        let text: *mut AnyObject = msg_send![transcription, formattedString];
-                        if !text.is_null() {
-                            let cstr: *const c_char = msg_send![text, UTF8String];
-                            if !cstr.is_null() {
-                                let s = CStr::from_ptr(cstr).to_string_lossy().to_string();
-                                let trimmed_len = s.trim().len();
-                                if let Ok(mut latest) = latest_for_handler.lock() {
-                                    *latest = s.clone();
-                                }
-
-                                let is_final: bool = msg_send![result, isFinal];
-                                if is_final {
-                                    log::info(&format!(
-                                        "Speech: final result received len={trimmed_len}"
-                                    ));
-                                    let _ = tx.send(Ok(s));
-                                }
-                                return;
-                            }
-                        }
-                    }
-
-                    let is_final: bool = msg_send![result, isFinal];
-                    if is_final {
-                        let _ = tx.send(Ok(String::new()));
-                    }
-                }
-            });
-
-            // -- Start recognition task --
-            let task: *mut AnyObject = msg_send![
-                recognizer,
-                recognitionTaskWithRequest: request,
-                resultHandler: &*block
-            ];
-
-            let result = match rx.recv_timeout(recognition_timeout) {
-                Ok(result) => result,
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    let latest = latest_transcription
-                        .lock()
-                        .ok()
-                        .map(|text| text.trim().to_string())
-                        .unwrap_or_default();
-                    log::info(&format!(
-                        "Speech: recognition timed out latest_len={}",
-                        latest.len()
-                    ));
-                    if latest.is_empty() {
-                        Err("Speech recognition timed out".to_string())
-                    } else {
-                        Ok(latest)
-                    }
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    log::info("Speech: recognition channel closed unexpectedly");
-                    Err("Speech recognition channel closed unexpectedly".to_string())
-                }
-            };
-
-            if !task.is_null() {
-                let _: () = msg_send![task, cancel];
-            }
-            let _: () = msg_send![pool, drain];
-            result
-        }
+        transcribe_with_helper(&helper, audio_path, locale, timeout)
     }
 
     fn recognition_timeout(audio_path: &Path) -> Duration {
@@ -213,36 +46,53 @@ mod platform {
         locale: &str,
         timeout: Duration,
     ) -> Result<String, String> {
+        let audio_metadata = describe_wav(audio_path).unwrap_or_else(|error| error);
         log::info(&format!(
-            "Speech: starting Swift helper path={audio_path:?} locale={locale} timeout={timeout:?}"
+            "SpeechAnalyzer: starting helper path={audio_path:?} locale={locale} timeout={timeout:?} {audio_metadata}"
         ));
+
         let output = Command::new(helper)
             .arg(audio_path)
             .arg(locale)
             .arg(format!("{:.3}", timeout.as_secs_f64()))
             .output()
-            .map_err(|error| format!("failed to run speech helper: {error}"))?;
+            .map_err(|error| format!("failed to run SpeechAnalyzer helper: {error}"))?;
 
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         if !stderr.is_empty() {
-            log::info(&format!("Speech helper: {stderr}"));
+            log::info(&format!("SpeechAnalyzer helper: {stderr}"));
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if output.status.success() {
             log::info(&format!(
-                "Speech: Swift helper completed len={}",
+                "SpeechAnalyzer: helper completed len={}",
                 stdout.len()
             ));
             return Ok(stdout);
         }
 
         let message = if stderr.is_empty() {
-            format!("speech helper failed with status {}", output.status)
+            format!("SpeechAnalyzer helper failed with status {}", output.status)
         } else {
             stderr
         };
         Err(message)
+    }
+
+    fn describe_wav(audio_path: &Path) -> Result<String, String> {
+        let reader = hound::WavReader::open(audio_path)
+            .map_err(|error| format!("wav_metadata_error={error}"))?;
+        let spec = reader.spec();
+        if spec.sample_rate == 0 || spec.channels == 0 {
+            return Err("wav_metadata_error=invalid_rate_or_channels".to_string());
+        }
+        let frames = reader.duration() as f64 / spec.channels as f64;
+        let duration = frames / spec.sample_rate as f64;
+        Ok(format!(
+            "duration={duration:.3}s sample_rate={} channels={} bits={} format={:?}",
+            spec.sample_rate, spec.channels, spec.bits_per_sample, spec.sample_format
+        ))
     }
 
     fn speech_helper_path() -> Option<PathBuf> {
@@ -261,70 +111,6 @@ mod platform {
 
         candidates.into_iter().find(|path| path.exists())
     }
-
-    unsafe fn ensure_speech_authorized(recognizer_cls: &'static AnyClass) -> Result<(), String> {
-        let status: isize = msg_send![recognizer_cls, authorizationStatus];
-        log::info(&format!(
-            "Speech: authorization status={}",
-            authorization_label(status)
-        ));
-
-        if status == AUTH_AUTHORIZED {
-            return Ok(());
-        }
-        if status == AUTH_DENIED || status == AUTH_RESTRICTED {
-            return Err(format!(
-                "Speech recognition permission is {}",
-                authorization_label(status)
-            ));
-        }
-        if status != AUTH_NOT_DETERMINED {
-            return Err(format!(
-                "Speech recognition permission is {}",
-                authorization_label(status)
-            ));
-        }
-
-        let (tx, rx) = mpsc::channel::<isize>();
-        let block = RcBlock::new(move |next_status: isize| {
-            let _ = tx.send(next_status);
-        });
-        let _: () = msg_send![recognizer_cls, requestAuthorization: &*block];
-
-        match rx.recv_timeout(Duration::from_secs(30)) {
-            Ok(next_status) => {
-                log::info(&format!(
-                    "Speech: authorization request returned status={}",
-                    authorization_label(next_status)
-                ));
-                if next_status == AUTH_AUTHORIZED {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "Speech recognition permission is {}",
-                        authorization_label(next_status)
-                    ))
-                }
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                log::info("Speech: authorization request timed out");
-                Err("Speech recognition permission request timed out".to_string())
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                Err("Speech recognition permission request was interrupted".to_string())
-            }
-        }
-    }
-
-    fn authorization_label(status: isize) -> &'static str {
-        match status {
-            AUTH_NOT_DETERMINED => "notDetermined",
-            AUTH_DENIED => "denied",
-            AUTH_RESTRICTED => "restricted",
-            AUTH_AUTHORIZED => "authorized",
-            _ => "unknown",
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -336,7 +122,7 @@ mod platform {
     use std::path::Path;
 
     pub fn transcribe(_audio_path: &Path, _locale: &str) -> Result<String, String> {
-        Err("On-device speech recognition is only available on macOS".into())
+        Err("On-device speech recognition is only available on macOS 26 or newer".into())
     }
 }
 

--- a/desktop/native-core/src/transcription.rs
+++ b/desktop/native-core/src/transcription.rs
@@ -10,7 +10,7 @@ use crate::formatting::FormattingStyle;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TranscriptionProvider {
-    /// On-device speech recognition. Currently available on macOS.
+    /// On-device SpeechAnalyzer recognition. Currently available on macOS 26+.
     None,
     Gemini,
     #[serde(rename = "openai")]
@@ -122,7 +122,7 @@ fn resolve_model(model: &str, provider: TranscriptionProvider) -> String {
 
 async fn transcribe_on_device(audio_path: &Path) -> Result<String, String> {
     // Delegate to the platform-native speech recognition module.
-    // On macOS this uses SFSpeechRecognizer; on other platforms it returns an error.
+    // On macOS this uses Apple's SpeechAnalyzer helper; on other platforms it returns an error.
     let path = audio_path.to_path_buf();
     let locale = crate::config::get().speech_recognition_locale();
     // Run on a blocking thread since the native API uses synchronous channel waiting.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "3.0.9",
+  "version": "4.0.0",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",

--- a/desktop/src/lib/settings/Settings.svelte
+++ b/desktop/src/lib/settings/Settings.svelte
@@ -1212,7 +1212,7 @@
                   <span class="field-description">
                     {isWindows
                       ? 'Choose an API provider to enable transcription.'
-                      : 'Uses macOS on-device speech recognition. Choose an API provider for more accurate transcription.'}
+                      : 'Uses Apple SpeechAnalyzer for on-device transcription on macOS 26 or newer. Choose an API provider for cloud transcription.'}
                   </span>
                 {/if}
               </div>

--- a/desktop/src/lib/settings/metadata.ts
+++ b/desktop/src/lib/settings/metadata.ts
@@ -46,7 +46,7 @@ interface ProviderOption {
 
 export function transcriptionProviders(isWindows: boolean): ProviderOption[] {
   return [
-    { value: 'none', label: isWindows ? 'On-device (macOS only)' : 'On-device', disabled: isWindows },
+    { value: 'none', label: isWindows ? 'On-device (macOS 26+)' : 'On-device (macOS 26+)', disabled: isWindows },
     { value: 'gemini', label: 'Gemini' },
     { value: 'openai', label: 'OpenAI' },
     { value: 'deepgram', label: 'Deepgram' },
@@ -113,7 +113,7 @@ export const styleExampleInput = 'yeah i was thinking we could try that new plac
 export const modifierOrder = ['cmd', 'ctrl', 'option', 'shift', 'fn'];
 
 export const providerLabels: Record<string, string> = {
-  none: 'On-device',
+  none: 'On-device (macOS 26+)',
   gemini: 'Gemini',
   openai: 'OpenAI',
   deepgram: 'Deepgram',


### PR DESCRIPTION
## Summary
- feat: migrate macOS on-device transcription to Apple SpeechAnalyzer and require macOS 26+ for local transcription
- fix: preserve final audio samples when stopping recording so trailing speech reaches transcription
- chore: bump version to 4.0.0

## Testing
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `pnpm run electron:build`
- [x] `pnpm run electron:package:ci`
- [x] Verified packaged `Yap.app` reports `CFBundleShortVersionString = 4.0.0` and `LSMinimumSystemVersion = 26.0`
- [x] Verified packaged `yap-speech` helper has `minos 26.0`

## Version Bump Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* ci: build macOS release artifacts on macOS 26 by @oobagi in https://github.com/oobagi/yap/pull/73
* feat: migrate macOS on-device transcription to Apple SpeechAnalyzer by @oobagi in this PR
* fix: preserve final audio samples when stopping recording by @oobagi in this PR
* chore: bump version to 4.0.0 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v3.0.9...v4.0.0
