### PR TITLE
Use macOS 26 for Electron builds

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
+          - platform: macos-26
             artifact-name: yap-electron-macos
           - platform: windows-latest
             artifact-name: yap-electron-windows


### PR DESCRIPTION
## Summary
- ci: run the macOS Electron build job on `macos-26` so release builds have Swift 6.2 and the macOS 26 SDK

## Testing
- [x] `git diff --check`

## Release Notes Preview
Internal CI prerequisite for the v4 SpeechAnalyzer release.
