### PR TITLE
Release v4.1.0

### DIFF
--- a/desktop/electron/main/config.ts
+++ b/desktop/electron/main/config.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 export type BackgroundAudioMode = "off" | "mute" | "pause";
+export type AppearanceMode = "system" | "light" | "dark";
 export type TranscriptionProvider = "none" | "gemini" | "openai" | "deepgram" | "elevenlabs";
 export type FormattingProvider = "none" | "gemini" | "openai" | "anthropic" | "groq";
 export type FormattingStyle = "casual" | "formatted" | "professional";
@@ -28,6 +29,7 @@ export interface AppConfig {
   geminiTemperature: number;
   elLanguageCode: string;
   soundsEnabled: boolean;
+  appearanceMode: AppearanceMode;
   backgroundAudioMode: BackgroundAudioMode;
   gradientEnabled: boolean;
   alwaysVisiblePill: boolean;
@@ -94,6 +96,7 @@ function defaultConfig(): AppConfig {
     geminiTemperature: 0,
     elLanguageCode: "",
     soundsEnabled: true,
+    appearanceMode: "system",
     backgroundAudioMode: "mute",
     gradientEnabled: true,
     alwaysVisiblePill: true,
@@ -120,6 +123,9 @@ function normalizeConfig(input: Partial<AppConfig> | null | undefined): AppConfi
     oaiPrompt: stringOrDefault(config.oaiPrompt, ""),
     elLanguageCode: stringOrDefault(config.elLanguageCode, ""),
     speechLocale: stringOrDefault(config.speechLocale, ""),
+    appearanceMode: isAppearanceMode(config.appearanceMode)
+      ? config.appearanceMode
+      : defaults.appearanceMode,
     backgroundAudioMode: isBackgroundAudioMode(config.backgroundAudioMode)
       ? config.backgroundAudioMode
       : defaults.backgroundAudioMode,
@@ -132,4 +138,8 @@ function stringOrDefault(value: unknown, fallback: string): string {
 
 function isBackgroundAudioMode(value: unknown): value is BackgroundAudioMode {
   return value === "off" || value === "mute" || value === "pause";
+}
+
+function isAppearanceMode(value: unknown): value is AppearanceMode {
+  return value === "system" || value === "light" || value === "dark";
 }

--- a/desktop/electron/main/index.ts
+++ b/desktop/electron/main/index.ts
@@ -9,6 +9,7 @@ import { YapCoreSidecar } from "./sidecar";
 import { installTray, refreshHistoryMenu } from "./tray";
 import {
   activateAppWindow,
+  applyNativeAppearance,
   createMainWindow,
   hideAppIfNoWindowsVisible,
   sendToAllWindows,
@@ -32,7 +33,8 @@ app.whenReady().then(async () => {
   configureAppIdentity();
   Menu.setApplicationMenu(null);
   installIpcHandlers(sidecar);
-  await loadConfig();
+  const config = await loadConfig();
+  applyNativeAppearance(config.appearanceMode);
   await permissions.preflight();
   await installTray({
     setEnabled: async (enabled) => {

--- a/desktop/electron/main/ipc.ts
+++ b/desktop/electron/main/ipc.ts
@@ -8,7 +8,13 @@ import {
   configureUpdater,
   downloadAndInstallElectronUpdate,
 } from "./updater";
-import { hideAppWindow, showAppWindow, windowLabelFor, type WindowLabel } from "./windows";
+import {
+  applyNativeAppearance,
+  hideAppWindow,
+  showAppWindow,
+  windowLabelFor,
+  type WindowLabel,
+} from "./windows";
 
 type InvokeArgs = Record<string, unknown>;
 
@@ -58,6 +64,12 @@ async function dispatchElectronLocal(
       return null;
     case "config.get":
       return loadConfig();
+    case "config.save": {
+      const result = await sidecar.invoke(command, args);
+      const config = await loadConfig();
+      applyNativeAppearance(config.appearanceMode);
+      return result;
+    }
     case "hotkey_capture.start": {
       const window = await showAppWindow("settings");
       startHotkeyCapture(window.webContents);
@@ -99,6 +111,7 @@ function isElectronLocalCommand(command: string): boolean {
     command === "window.open_main" ||
     command === "window.hide" ||
     command === "config.get" ||
+    command === "config.save" ||
     command === "hotkey_capture.start" ||
     command === "hotkey_capture.cancel" ||
     command === "history_menu.refresh" ||

--- a/desktop/electron/main/windows.ts
+++ b/desktop/electron/main/windows.ts
@@ -1,11 +1,29 @@
-import { app, BrowserWindow, shell } from "electron";
+import { app, BrowserWindow, nativeTheme, shell, type NativeTheme } from "electron";
 import { join } from "node:path";
+import type { AppearanceMode } from "./config";
 import { appIconPath, appRoot, preloadPath, rendererDevUrl } from "./paths";
 
 export type WindowLabel = "main" | "settings";
 
 const windows = new Map<WindowLabel, BrowserWindow>();
 let isQuitting = false;
+
+const windowPalettes = {
+  dark: {
+    background: "#101215",
+    titleBar: "#101215",
+    titleBarSymbol: "#f6f7f9",
+  },
+  light: {
+    background: "#f4f1ec",
+    titleBar: "#f4f1ec",
+    titleBarSymbol: "#1d1a16",
+  },
+} as const;
+
+nativeTheme.on("updated", () => {
+  applyAppearanceToAllWindows();
+});
 
 app.on("before-quit", () => {
   isQuitting = true;
@@ -85,6 +103,11 @@ export function sendToAllWindows(event: string, payload?: unknown): void {
   }
 }
 
+export function applyNativeAppearance(mode: AppearanceMode): void {
+  nativeTheme.themeSource = mode as NativeTheme["themeSource"];
+  applyAppearanceToAllWindows();
+}
+
 export async function createMainWindow(): Promise<BrowserWindow> {
   const existing = getWindow("main");
   if (existing) return existing;
@@ -133,6 +156,7 @@ function createFramelessWindow(
     fullscreenable?: boolean;
   }
 ): BrowserWindow {
+  const palette = resolvedWindowPalette();
   const window = new BrowserWindow({
     ...options,
     show: false,
@@ -142,13 +166,13 @@ function createFramelessWindow(
       process.platform === "darwin"
         ? false
         : {
-            color: "#101215",
-            symbolColor: "#f6f7f9",
+            color: palette.titleBar,
+            symbolColor: palette.titleBarSymbol,
             height: 36,
           },
     trafficLightPosition: { x: 14, y: 14 },
     icon: appIconPath(),
-    backgroundColor: "#101215",
+    backgroundColor: palette.background,
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,
@@ -180,6 +204,25 @@ function createFramelessWindow(
   });
 
   return window;
+}
+
+function applyAppearanceToAllWindows(): void {
+  const palette = resolvedWindowPalette();
+  for (const window of windows.values()) {
+    if (window.isDestroyed()) continue;
+    window.setBackgroundColor(palette.background);
+    if (process.platform !== "darwin") {
+      window.setTitleBarOverlay({
+        color: palette.titleBar,
+        symbolColor: palette.titleBarSymbol,
+        height: 36,
+      });
+    }
+  }
+}
+
+function resolvedWindowPalette(): (typeof windowPalettes)[keyof typeof windowPalettes] {
+  return nativeTheme.shouldUseDarkColors ? windowPalettes.dark : windowPalettes.light;
 }
 
 async function loadRenderer(window: BrowserWindow, label: WindowLabel): Promise<void> {

--- a/desktop/native-core/Cargo.lock
+++ b/desktop/native-core/Cargo.lock
@@ -3339,7 +3339,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yap"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "arboard",
  "base64",

--- a/desktop/native-core/Cargo.toml
+++ b/desktop/native-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yap"
-version = "4.0.0"
+version = "4.1.0"
 description = "Yap - Cross-platform voice-to-text"
 authors = ["igaboo"]
 edition = "2021"

--- a/desktop/native-core/sidecar-overlay/Sources/IPCProtocol.swift
+++ b/desktop/native-core/sidecar-overlay/Sources/IPCProtocol.swift
@@ -34,6 +34,7 @@ struct IPCMessage: Decodable {
     // config
     let gradientEnabled: Bool?
     let alwaysVisible: Bool?
+    let appearanceMode: String?
 }
 
 // MARK: - Outbound (Sidecar → Electron, stdout)

--- a/desktop/native-core/sidecar-overlay/Sources/OverlayPanel.swift
+++ b/desktop/native-core/sidecar-overlay/Sources/OverlayPanel.swift
@@ -1,6 +1,51 @@
 import Cocoa
 import SwiftUI
 
+enum ProductAppearanceMode: String {
+    case system
+    case light
+    case dark
+
+    static func from(_ value: String?) -> ProductAppearanceMode? {
+        guard let value else { return nil }
+        return ProductAppearanceMode(rawValue: value) ?? .system
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}
+
+struct OverlayPalette {
+    let isDark: Bool
+
+    init(colorScheme: ColorScheme) {
+        isDark = colorScheme == .dark
+    }
+
+    var text: Color { isDark ? .white : Color(red: 0.12, green: 0.10, blue: 0.08) }
+    var secondaryText: Color { text.opacity(isDark ? 0.78 : 0.72) }
+    var subtleText: Color { text.opacity(isDark ? 0.5 : 0.54) }
+    var pillFill: Color { isDark ? .black : .white }
+    var pillExpandedOpacity: Double { isDark ? 0.75 : 0.82 }
+    var pillIdleOpacity: Double { isDark ? 0.4 : 0.58 }
+    var border: Color { isDark ? .white.opacity(0.3) : .black.opacity(0.14) }
+    var idleBorder: Color { isDark ? .white.opacity(0.35) : .black.opacity(0.18) }
+    var shadow: Color { .black.opacity(isDark ? 0.35 : 0.18) }
+    var lightShadow: Color { .black.opacity(isDark ? 0.1 : 0.08) }
+    var controlFill: Color { isDark ? .white.opacity(0.15) : .black.opacity(0.08) }
+    var actionFill: Color { isDark ? .white.opacity(0.9) : .black.opacity(0.84) }
+    var actionText: Color { isDark ? .black.opacity(0.88) : .white.opacity(0.96) }
+    var keyFill: Color { isDark ? Color(white: 0.25) : Color(red: 0.92, green: 0.90, blue: 0.86) }
+    var keyBorder: Color { isDark ? Color(white: 0.45) : .black.opacity(0.18) }
+    var keyShadow: Color { .black.opacity(isDark ? 0.5 : 0.16) }
+    var bar: Color { isDark ? .white : Color(red: 0.16, green: 0.14, blue: 0.12) }
+}
+
 // MARK: - Hit targets
 
 /// Small transparent child panel for the few regions that should remain clickable.
@@ -323,8 +368,9 @@ class OverlayPanel: NSPanel {
         }
     }
 
-    func applyConfig(gradientEnabled: Bool?, alwaysVisible: Bool?, hotkeyLabel: String?) {
+    func applyConfig(gradientEnabled: Bool?, alwaysVisible: Bool?, appearanceMode: String?, hotkeyLabel: String?) {
         if let g = gradientEnabled { overlayState.gradientEnabled = g }
+        if let mode = ProductAppearanceMode.from(appearanceMode) { overlayState.appearanceMode = mode }
         if let label = hotkeyLabel { overlayState.hotkeyLabel = label }
         if let visible = alwaysVisible {
             overlayState.alwaysVisible = visible
@@ -545,6 +591,7 @@ class OverlayState: ObservableObject {
     @Published var isHovering: Bool = false
     @Published var gradientEnabled: Bool = true
     @Published var alwaysVisible: Bool = true
+    @Published var appearanceMode: ProductAppearanceMode = .system
     @Published var recordingElapsed: TimeInterval = 0
     var onPermissionAction: (() -> Void)?
     var onPauseResume: (() -> Void)?
@@ -558,10 +605,12 @@ class OverlayState: ObservableObject {
 struct OverlayView: View {
     @ObservedObject var state: OverlayState
     @State private var shakeProgress: CGFloat = 0
+    @Environment(\.colorScheme) private var colorScheme
 
     private var isActive: Bool { state.mode != .idle || state.isOnboarding || state.permissionPrompt != nil }
     private var isExpanded: Bool { state.mode != .idle || state.isOnboarding || state.permissionPrompt != nil }
     private var isMinimized: Bool { state.mode == .idle && !state.isOnboarding && state.permissionPrompt == nil }
+    private var palette: OverlayPalette { OverlayPalette(colorScheme: colorScheme) }
 
     private var gradientEnergy: CGFloat {
         switch state.mode {
@@ -626,7 +675,7 @@ struct OverlayView: View {
                     if showRecordingTimer {
                         Text(formatElapsed(state.recordingElapsed))
                             .font(.system(size: 11, weight: .medium, design: .monospaced))
-                            .foregroundColor(.white.opacity(0.5))
+                            .foregroundColor(palette.subtleText)
                             .fixedSize()
                             .transition(.opacity.combined(with: .offset(y: 12)))
                     }
@@ -643,15 +692,15 @@ struct OverlayView: View {
                     .padding(.vertical, 6)
                     .background(
                         ZStack {
-                            Capsule().fill(Color.black.opacity(isExpanded ? 0.75 : 0.4))
+                            Capsule().fill(palette.pillFill.opacity(isExpanded ? palette.pillExpandedOpacity : palette.pillIdleOpacity))
                             Capsule().fill(.thinMaterial)
                         }
-                        .shadow(color: .black.opacity(isExpanded ? 0.35 : 0.1),
+                        .shadow(color: isExpanded ? palette.shadow : palette.lightShadow,
                                 radius: isExpanded ? 16 : 6, y: isExpanded ? 4 : 2)
                     )
                     .overlay(
                         Capsule()
-                            .strokeBorder(Color.white.opacity(isExpanded ? 0.3 : 0.35),
+                            .strokeBorder(isExpanded ? palette.border : palette.idleBorder,
                                           lineWidth: isExpanded ? 1 : 1.5)
                     )
                     .contentShape(Capsule())
@@ -678,8 +727,8 @@ struct OverlayView: View {
                         if state.isHovering && isMinimized {
                             Text("Click to start transcribing")
                                 .font(.system(size: 13, weight: .semibold))
-                                .foregroundColor(.white)
-                                .shadow(color: .black.opacity(0.6), radius: 6, y: 2)
+                                .foregroundColor(palette.text)
+                                .shadow(color: palette.shadow, radius: 6, y: 2)
                                 .fixedSize()
                                 .allowsHitTesting(false)
                                 .offset(y: OverlayLayout.hoverTooltipYOffset)
@@ -704,6 +753,7 @@ struct OverlayView: View {
         .onChange(of: state.mode) { _ in
             if state.mode != .idle { state.isHovering = false }
         }
+        .preferredColorScheme(state.appearanceMode.colorScheme)
     }
 
     private var pillScale: CGFloat {
@@ -751,9 +801,9 @@ struct OverlayView: View {
 
                     Image(systemName: state.isPaused ? "play.fill" : "pause.fill")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.9))
+                        .foregroundColor(palette.text.opacity(0.9))
                         .frame(width: 26, height: 26)
-                        .background(Circle().fill(Color.white.opacity(0.15)))
+                        .background(Circle().fill(palette.controlFill))
                         .contentShape(Circle())
                         .onTapGesture { state.onPauseResume?() }
                         .offset(x: state.isHandsFree ? -49 : 0)
@@ -787,7 +837,7 @@ struct OverlayView: View {
                 } else if state.isHovering {
                     Image(systemName: "mic.fill")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.9))
+                        .foregroundColor(palette.text.opacity(0.9))
                         .frame(width: 28, height: 28)
                         .transition(.opacity)
                 } else {
@@ -801,7 +851,7 @@ struct OverlayView: View {
         HStack(spacing: 2) {
             ForEach(0..<11, id: \.self) { _ in
                 RoundedRectangle(cornerRadius: 1.5)
-                    .fill(Color.white.opacity(0.25))
+                    .fill(palette.bar.opacity(0.25))
                     .frame(width: 3, height: 5)
             }
         }
@@ -842,19 +892,24 @@ struct LavaLampBackground: View {
 
 struct KeyCapView: View {
     let label: String
+    @Environment(\.colorScheme) private var colorScheme
+    private var palette: OverlayPalette { OverlayPalette(colorScheme: colorScheme) }
+
     var body: some View {
         Text(label)
             .font(.system(size: 12, weight: .semibold, design: .rounded))
-            .foregroundColor(.white)
+            .foregroundColor(palette.text)
             .padding(.horizontal, 10).padding(.vertical, 5)
-            .background(RoundedRectangle(cornerRadius: 5).fill(Color(white: 0.25)))
-            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(white: 0.45), lineWidth: 1))
-            .shadow(color: .black.opacity(0.5), radius: 1, y: 1)
+            .background(RoundedRectangle(cornerRadius: 5).fill(palette.keyFill))
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(palette.keyBorder, lineWidth: 1))
+            .shadow(color: palette.keyShadow, radius: 1, y: 1)
     }
 }
 
 struct ErrorCardView: View {
     let message: String
+    @Environment(\.colorScheme) private var colorScheme
+    private var palette: OverlayPalette { OverlayPalette(colorScheme: colorScheme) }
 
     var body: some View {
         HStack(spacing: 6) {
@@ -863,63 +918,65 @@ struct ErrorCardView: View {
                 .foregroundColor(.red)
             Text(message)
                 .font(.system(size: 15, weight: .medium))
-                .foregroundColor(.white.opacity(0.9))
+                .foregroundColor(palette.text.opacity(0.9))
                 .lineLimit(1)
         }
         .padding(.horizontal, 16).padding(.vertical, 10)
         .fixedSize()
         .background(
             ZStack {
-                RoundedRectangle(cornerRadius: 25).fill(Color.black.opacity(0.75))
+                RoundedRectangle(cornerRadius: 25).fill(palette.pillFill.opacity(palette.pillExpandedOpacity))
                 RoundedRectangle(cornerRadius: 25).fill(.thinMaterial)
             }
-            .shadow(color: .black.opacity(0.35), radius: 16, y: 4)
+            .shadow(color: palette.shadow, radius: 16, y: 4)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 25).strokeBorder(Color.white.opacity(0.3), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 25).strokeBorder(palette.border, lineWidth: 1)
         )
     }
 }
 
 struct PermissionCardView: View {
     let prompt: PermissionPrompt
+    @Environment(\.colorScheme) private var colorScheme
+    private var palette: OverlayPalette { OverlayPalette(colorScheme: colorScheme) }
 
     var body: some View {
         VStack(spacing: 9) {
             HStack(spacing: 7) {
                 Image(systemName: "lock.open.fill")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.85))
+                    .foregroundColor(palette.text.opacity(0.85))
                 Text(prompt.title)
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(palette.text)
             }
 
             Text(prompt.message)
                 .font(.system(size: 13, weight: .medium))
-                .foregroundColor(.white.opacity(0.78))
+                .foregroundColor(palette.secondaryText)
                 .multilineTextAlignment(.center)
                 .lineLimit(4)
                 .frame(width: 315)
 
             Text(prompt.actionLabel)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.black.opacity(0.88))
+                .foregroundColor(palette.actionText)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 7)
-                .background(Capsule().fill(Color.white.opacity(0.9)))
+                .background(Capsule().fill(palette.actionFill))
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
         .background(
             ZStack {
-                RoundedRectangle(cornerRadius: 18).fill(Color.black.opacity(0.78))
+                RoundedRectangle(cornerRadius: 18).fill(palette.pillFill.opacity(palette.pillExpandedOpacity))
                 RoundedRectangle(cornerRadius: 18).fill(.thinMaterial)
             }
-            .shadow(color: .black.opacity(0.35), radius: 16, y: 4)
+            .shadow(color: palette.shadow, radius: 16, y: 4)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 18).strokeBorder(Color.white.opacity(0.3), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 18).strokeBorder(palette.border, lineWidth: 1)
         )
         .allowsHitTesting(false)
     }
@@ -928,6 +985,8 @@ struct PermissionCardView: View {
 struct PromptInlineView: View {
     let step: OnboardingStep
     var hotkeyLabel: String = "fn"
+    @Environment(\.colorScheme) private var colorScheme
+    private var palette: OverlayPalette { OverlayPalette(colorScheme: colorScheme) }
 
     var body: some View {
         HStack(spacing: 6) {
@@ -936,30 +995,32 @@ struct PromptInlineView: View {
             Text(step == .welcome ? "to finish" : "to continue")
         }
         .font(.system(size: 12, weight: .medium))
-        .foregroundColor(.white.opacity(0.8))
+        .foregroundColor(palette.secondaryText)
     }
 }
 
 struct PromptCardView: View {
     let step: OnboardingStep
     var hotkeyLabel: String = "fn"
+    @Environment(\.colorScheme) private var colorScheme
+    private var palette: OverlayPalette { OverlayPalette(colorScheme: colorScheme) }
 
     var body: some View {
         cardContent
             .font(.system(size: 15, weight: .medium))
-            .foregroundColor(.white)
+            .foregroundColor(palette.text)
             .multilineTextAlignment(.center)
             .padding(.horizontal, 16).padding(.vertical, 10)
             .fixedSize()
             .background(
                 ZStack {
-                    RoundedRectangle(cornerRadius: 25).fill(Color.black.opacity(0.75))
+                    RoundedRectangle(cornerRadius: 25).fill(palette.pillFill.opacity(palette.pillExpandedOpacity))
                     RoundedRectangle(cornerRadius: 25).fill(.thinMaterial)
                 }
-                .shadow(color: .black.opacity(0.35), radius: 16, y: 4)
+                .shadow(color: palette.shadow, radius: 16, y: 4)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 25).strokeBorder(Color.white.opacity(0.3), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 25).strokeBorder(palette.border, lineWidth: 1)
             )
     }
 
@@ -995,6 +1056,8 @@ struct BarVisualizer: View {
     @State private var waveStrength: CGFloat = 0
     @State private var audioDecay: CGFloat = 1
     @State private var waveStart: Date? = nil
+    @Environment(\.colorScheme) private var colorScheme
+    private var palette: OverlayPalette { OverlayPalette(colorScheme: colorScheme) }
 
     var body: some View {
         TimelineView(.animation(paused: !isProcessing)) { timeline in
@@ -1027,7 +1090,7 @@ struct BarVisualizer: View {
                     let barOpacity = isActive ? (isProcessing ? shimmer : 0.9) : 0.25
 
                     RoundedRectangle(cornerRadius: 1.5)
-                        .fill(Color.white.opacity(barOpacity))
+                        .fill(palette.bar.opacity(barOpacity))
                         .frame(width: 3, height: barHeight)
                         .animation(.interpolatingSpring(stiffness: 280, damping: 18), value: bandLevel)
                         .animation(.easeOut(duration: 0.18), value: isActive)

--- a/desktop/native-core/sidecar-overlay/Sources/main.swift
+++ b/desktop/native-core/sidecar-overlay/Sources/main.swift
@@ -73,6 +73,7 @@ DispatchQueue.global(qos: .userInteractive).async {
                 panel.applyConfig(
                     gradientEnabled: msg.gradientEnabled,
                     alwaysVisible: msg.alwaysVisible,
+                    appearanceMode: msg.appearanceMode,
                     hotkeyLabel: msg.hotkeyLabel
                 )
 

--- a/desktop/native-core/src/config.rs
+++ b/desktop/native-core/src/config.rs
@@ -20,6 +20,31 @@ impl Default for BackgroundAudioMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AppearanceMode {
+    Light,
+    Dark,
+    #[serde(other)]
+    System,
+}
+
+impl AppearanceMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::Light => "light",
+            Self::Dark => "dark",
+        }
+    }
+}
+
+impl Default for AppearanceMode {
+    fn default() -> Self {
+        Self::System
+    }
+}
+
 /// Full app configuration, plus serde defaults for each persisted field.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -101,6 +126,10 @@ pub struct AppConfig {
     #[serde(default = "default_true")]
     pub sounds_enabled: bool,
 
+    /// Product appearance preference.
+    #[serde(default)]
+    pub appearance_mode: AppearanceMode,
+
     /// How Yap should handle background audio while recording.
     #[serde(default)]
     pub background_audio_mode: BackgroundAudioMode,
@@ -176,6 +205,7 @@ impl Default for AppConfig {
             gemini_temperature: 0.0,
             el_language_code: String::new(),
             sounds_enabled: true,
+            appearance_mode: AppearanceMode::System,
             background_audio_mode: BackgroundAudioMode::Mute,
             gradient_enabled: true,
             always_visible_pill: true,

--- a/desktop/native-core/src/dictation.rs
+++ b/desktop/native-core/src/dictation.rs
@@ -1010,6 +1010,7 @@ fn emit_overlay_config(cfg: &AppConfig) {
     crate::sidecar::send(&crate::sidecar::OutMessage::Config {
         gradient_enabled: cfg.gradient_enabled,
         always_visible: cfg.always_visible_pill,
+        appearance_mode: cfg.appearance_mode.as_str().to_string(),
         hotkey_label: HotkeySpec::parse(&cfg.hotkey).label(),
     });
 }
@@ -1019,6 +1020,7 @@ fn emit_overlay_config(cfg: &AppConfig) {
     crate::win_overlay::update_state(|state| {
         state.gradient_enabled = cfg.gradient_enabled;
         state.always_visible = cfg.always_visible_pill;
+        state.appearance_mode = cfg.appearance_mode;
         state.hotkey_label = HotkeySpec::parse(&cfg.hotkey).label();
     });
 }

--- a/desktop/native-core/src/sidecar.rs
+++ b/desktop/native-core/src/sidecar.rs
@@ -64,6 +64,8 @@ pub enum OutMessage {
         gradient_enabled: bool,
         #[serde(rename = "alwaysVisible")]
         always_visible: bool,
+        #[serde(rename = "appearanceMode")]
+        appearance_mode: String,
         #[serde(rename = "hotkeyLabel")]
         hotkey_label: String,
     },

--- a/desktop/native-core/src/win_overlay.rs
+++ b/desktop/native-core/src/win_overlay.rs
@@ -28,6 +28,8 @@ use windows::Win32::UI::Controls::WM_MOUSELEAVE;
 use windows::Win32::UI::Input::KeyboardAndMouse::{TrackMouseEvent, TME_LEAVE, TRACKMOUSEEVENT};
 use windows::Win32::UI::WindowsAndMessaging::*;
 
+use crate::config::AppearanceMode;
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -197,6 +199,7 @@ pub struct OverlayState {
     // Config
     pub gradient_enabled: bool,
     pub always_visible: bool,
+    pub appearance_mode: AppearanceMode,
 
     // Pressed state (onboarding key press visual)
     pub is_pressed: bool,
@@ -217,7 +220,77 @@ impl Default for OverlayState {
             hotkey_label: "fn".into(),
             gradient_enabled: true,
             always_visible: true,
+            appearance_mode: AppearanceMode::System,
             is_pressed: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct OverlayPalette {
+    is_dark: bool,
+}
+
+impl OverlayPalette {
+    fn from_state(state: &OverlayState) -> Self {
+        Self {
+            is_dark: !matches!(state.appearance_mode, AppearanceMode::Light),
+        }
+    }
+
+    fn text(self, alpha: u8) -> [u8; 4] {
+        if self.is_dark {
+            [255, 255, 255, alpha]
+        } else {
+            [31, 26, 22, alpha]
+        }
+    }
+
+    fn pill_fill(self, expanded: bool) -> [u8; 4] {
+        if self.is_dark {
+            [15, 15, 26, if expanded { 191 } else { 102 }]
+        } else {
+            [255, 251, 245, if expanded { 209 } else { 148 }]
+        }
+    }
+
+    fn border(self, expanded: bool) -> [u8; 4] {
+        if self.is_dark {
+            [255, 255, 255, if expanded { 77 } else { 89 }]
+        } else {
+            [0, 0, 0, if expanded { 36 } else { 46 }]
+        }
+    }
+
+    fn bar(self, alpha: u8) -> [u8; 4] {
+        if self.is_dark {
+            [255, 255, 255, alpha]
+        } else {
+            [41, 36, 31, alpha]
+        }
+    }
+
+    fn control_fill(self, alpha: u8) -> [u8; 4] {
+        if self.is_dark {
+            [255, 255, 255, alpha]
+        } else {
+            [0, 0, 0, alpha]
+        }
+    }
+
+    fn key_fill(self) -> [u8; 4] {
+        if self.is_dark {
+            [64, 64, 64, 255]
+        } else {
+            [235, 229, 219, 255]
+        }
+    }
+
+    fn key_border(self) -> [u8; 4] {
+        if self.is_dark {
+            [115, 115, 115, 255]
+        } else {
+            [0, 0, 0, 46]
         }
     }
 }
@@ -1337,6 +1410,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
     let geom = overlay_geometry(&state, Some(anim));
     let cx = geom.cx;
     let pill_cy = geom.pill_cy;
+    let palette = OverlayPalette::from_state(&state);
 
     // -- Lava lamp gradient --
     if anim.gradient_opacity.val() > 0.01 {
@@ -1355,6 +1429,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
                     &state.hotkey_label,
                     cx,
                     pill_cy - CARD_GAP_Y,
+                    &palette,
                 );
             }
         }
@@ -1364,7 +1439,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
     if state.mode == "error" {
         if let Some(ref msg) = state.error {
             if let Some(ref fr) = font {
-                render_error_card(&mut pixmap, fr, msg, cx, pill_cy - CARD_GAP_Y);
+                render_error_card(&mut pixmap, fr, msg, cx, pill_cy - CARD_GAP_Y, &palette);
             }
         }
     }
@@ -1381,7 +1456,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
                 cx,
                 pill_cy - TIMER_GAP_Y + (1.0 - timer_opacity) * 12.0,
                 11.0,
-                [255, 255, 255, alpha],
+                palette.text(alpha),
             );
         }
     }
@@ -1398,8 +1473,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
     // Pill capsule background
     let capsule = rounded_rect(pill_x, pill_y, pill_w, pill_h, pill_r);
     let mut bg_paint = tiny_skia::Paint::default();
-    let bg_alpha = if is_expanded { 0.75 } else { 0.4 };
-    bg_paint.set_color(tiny_skia::Color::from_rgba(0.06, 0.06, 0.1, bg_alpha).unwrap());
+    bg_paint.set_color(color_from_rgba8(palette.pill_fill(is_expanded)));
     bg_paint.anti_alias = true;
     pixmap.fill_path(
         &capsule,
@@ -1410,9 +1484,8 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
     );
 
     // Pill border
-    let border_alpha = if is_expanded { 0.3 } else { 0.35 };
     let mut border_paint = tiny_skia::Paint::default();
-    border_paint.set_color(tiny_skia::Color::from_rgba(1.0, 1.0, 1.0, border_alpha).unwrap());
+    border_paint.set_color(color_from_rgba8(palette.border(is_expanded)));
     border_paint.anti_alias = true;
     let stroke = tiny_skia::Stroke {
         width: if is_expanded { 1.0 } else { 1.5 },
@@ -1441,7 +1514,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
                 let start_x = pill_content_cx - total_w / 2.0;
 
                 let text_y = pill_cy + 4.0 * pill_scale;
-                let color = [255, 255, 255, 200];
+                let color = palette.text(200);
                 let mut x = start_x;
                 x += fr.render(&mut pixmap, "Hold ", x, text_y, font_size, color);
                 // Draw keycap
@@ -1452,13 +1525,14 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
                     x,
                     pill_cy,
                     font_size,
+                    &palette,
                 );
                 x += key_w + gap;
                 fr.render(&mut pixmap, suffix, x, text_y, font_size, color);
             }
         } else if state.mode == "idle" || state.mode == "noSpeech" {
             // Flat bars for onboarding idle
-            render_flat_bars(&mut pixmap, pill_content_cx, pill_cy, pill_scale);
+            render_flat_bars(&mut pixmap, pill_content_cx, pill_cy, pill_scale, &palette);
         }
     }
 
@@ -1474,22 +1548,37 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
                     pill_cy,
                     pill_scale,
                     controls_progress,
+                    &palette,
                 );
             } else {
-                render_bars(&mut pixmap, anim, pill_content_cx, pill_cy, pill_scale);
+                render_bars(
+                    &mut pixmap,
+                    anim,
+                    pill_content_cx,
+                    pill_cy,
+                    pill_scale,
+                    &palette,
+                );
             }
         }
         "pending" => {
-            render_bars(&mut pixmap, anim, pill_content_cx, pill_cy, pill_scale);
+            render_bars(
+                &mut pixmap,
+                anim,
+                pill_content_cx,
+                pill_cy,
+                pill_scale,
+                &palette,
+            );
         }
         "error" => {
-            render_flat_bars(&mut pixmap, pill_content_cx, pill_cy, pill_scale);
+            render_flat_bars(&mut pixmap, pill_content_cx, pill_cy, pill_scale, &palette);
         }
         "noSpeech" => {
             if state.onboarding_step.is_none()
                 || !state.onboarding_step.as_ref().unwrap().shows_hold_prompt()
             {
-                render_flat_bars(&mut pixmap, pill_content_cx, pill_cy, pill_scale);
+                render_flat_bars(&mut pixmap, pill_content_cx, pill_cy, pill_scale, &palette);
             }
         }
         "idle" => {}
@@ -1510,7 +1599,7 @@ fn render_frame(hwnd: HWND, anim: &mut AnimState, font: &Option<FontRenderer>) {
                 cx,
                 tooltip_y,
                 13.0,
-                [255, 255, 255, alpha],
+                palette.text(alpha),
             );
         }
     }
@@ -1678,7 +1767,24 @@ fn gradient_dither(x: u32, y: u32) -> f32 {
     ((n ^ (n >> 16)) & 0xff) as f32 / 255.0
 }
 
-fn render_bars(pixmap: &mut tiny_skia::Pixmap, anim: &AnimState, cx: f32, cy: f32, scale: f32) {
+fn color_from_rgba8(color: [u8; 4]) -> tiny_skia::Color {
+    tiny_skia::Color::from_rgba(
+        color[0] as f32 / 255.0,
+        color[1] as f32 / 255.0,
+        color[2] as f32 / 255.0,
+        color[3] as f32 / 255.0,
+    )
+    .unwrap()
+}
+
+fn render_bars(
+    pixmap: &mut tiny_skia::Pixmap,
+    anim: &AnimState,
+    cx: f32,
+    cy: f32,
+    scale: f32,
+    palette: &OverlayPalette,
+) {
     let bar_w = BAR_W * scale;
     let bar_gap = BAR_GAP * scale;
     let bars_total_w = BARS_TOTAL_W * scale;
@@ -1692,7 +1798,8 @@ fn render_bars(pixmap: &mut tiny_skia::Pixmap, anim: &AnimState, cx: f32, cy: f3
 
         let bar_path = rounded_rect(x, y, bar_w, bar_h, 1.5 * scale);
         let mut paint = tiny_skia::Paint::default();
-        paint.set_color(tiny_skia::Color::from_rgba(1.0, 1.0, 1.0, opacity).unwrap());
+        let alpha = (opacity * 255.0).round().clamp(0.0, 255.0) as u8;
+        paint.set_color(color_from_rgba8(palette.bar(alpha)));
         paint.anti_alias = true;
         pixmap.fill_path(
             &bar_path,
@@ -1712,12 +1819,13 @@ fn render_hands_free_content(
     cy: f32,
     scale: f32,
     controls_progress: f32,
+    palette: &OverlayPalette,
 ) {
     // Bars in center
     if state.paused {
-        render_flat_bars(pixmap, cx, cy, scale);
+        render_flat_bars(pixmap, cx, cy, scale, palette);
     } else {
-        render_bars(pixmap, anim, cx, cy, scale);
+        render_bars(pixmap, anim, cx, cy, scale, palette);
     }
 
     // Pause button (left)
@@ -1731,12 +1839,12 @@ fn render_hands_free_content(
             pause_cx,
             cy,
             13.0 * control_scale,
-            [255, 255, 255, (38.0 * control_alpha) as u8],
+            palette.control_fill((38.0 * control_alpha) as u8),
         );
         if state.paused {
-            draw_play_icon(pixmap, pause_cx, cy, control_scale, control_alpha);
+            draw_play_icon(pixmap, pause_cx, cy, control_scale, control_alpha, palette);
         } else {
-            draw_pause_icon(pixmap, pause_cx, cy, control_scale, control_alpha);
+            draw_pause_icon(pixmap, pause_cx, cy, control_scale, control_alpha, palette);
         }
 
         // Stop button (right)
@@ -1752,7 +1860,13 @@ fn render_hands_free_content(
     }
 }
 
-fn render_flat_bars(pixmap: &mut tiny_skia::Pixmap, cx: f32, cy: f32, scale: f32) {
+fn render_flat_bars(
+    pixmap: &mut tiny_skia::Pixmap,
+    cx: f32,
+    cy: f32,
+    scale: f32,
+    palette: &OverlayPalette,
+) {
     let bar_w = BAR_W * scale;
     let bar_gap = BAR_GAP * scale;
     let bar_h = BAR_MIN_H * scale;
@@ -1762,7 +1876,7 @@ fn render_flat_bars(pixmap: &mut tiny_skia::Pixmap, cx: f32, cy: f32, scale: f32
         let y = cy - bar_h / 2.0;
         let bar_path = rounded_rect(x, y, bar_w, bar_h, 1.5 * scale);
         let mut paint = tiny_skia::Paint::default();
-        paint.set_color(tiny_skia::Color::from_rgba(1.0, 1.0, 1.0, 0.25).unwrap());
+        paint.set_color(color_from_rgba8(palette.bar(64)));
         paint.anti_alias = true;
         pixmap.fill_path(
             &bar_path,
@@ -1787,15 +1901,7 @@ fn render_circle_button(pixmap: &mut tiny_skia::Pixmap, cx: f32, cy: f32, r: f32
     pb.close();
     if let Some(path) = pb.finish() {
         let mut paint = tiny_skia::Paint::default();
-        paint.set_color(
-            tiny_skia::Color::from_rgba(
-                color[0] as f32 / 255.0,
-                color[1] as f32 / 255.0,
-                color[2] as f32 / 255.0,
-                color[3] as f32 / 255.0,
-            )
-            .unwrap(),
-        );
+        paint.set_color(color_from_rgba8(color));
         paint.anti_alias = true;
         pixmap.fill_path(
             &path,
@@ -1807,9 +1913,18 @@ fn render_circle_button(pixmap: &mut tiny_skia::Pixmap, cx: f32, cy: f32, r: f32
     }
 }
 
-fn draw_pause_icon(pixmap: &mut tiny_skia::Pixmap, cx: f32, cy: f32, scale: f32, alpha: f32) {
+fn draw_pause_icon(
+    pixmap: &mut tiny_skia::Pixmap,
+    cx: f32,
+    cy: f32,
+    scale: f32,
+    alpha: f32,
+    palette: &OverlayPalette,
+) {
     let mut paint = tiny_skia::Paint::default();
-    paint.set_color(tiny_skia::Color::from_rgba(1.0, 1.0, 1.0, 0.9 * alpha).unwrap());
+    paint.set_color(color_from_rgba8(
+        palette.text((0.9 * alpha * 255.0).round().clamp(0.0, 255.0) as u8),
+    ));
     paint.anti_alias = true;
     // Two vertical bars
     let bar_w = 2.5 * scale;
@@ -1839,9 +1954,18 @@ fn draw_pause_icon(pixmap: &mut tiny_skia::Pixmap, cx: f32, cy: f32, scale: f32,
     );
 }
 
-fn draw_play_icon(pixmap: &mut tiny_skia::Pixmap, cx: f32, cy: f32, scale: f32, alpha: f32) {
+fn draw_play_icon(
+    pixmap: &mut tiny_skia::Pixmap,
+    cx: f32,
+    cy: f32,
+    scale: f32,
+    alpha: f32,
+    palette: &OverlayPalette,
+) {
     let mut paint = tiny_skia::Paint::default();
-    paint.set_color(tiny_skia::Color::from_rgba(1.0, 1.0, 1.0, 0.9 * alpha).unwrap());
+    paint.set_color(color_from_rgba8(
+        palette.text((0.9 * alpha * 255.0).round().clamp(0.0, 255.0) as u8),
+    ));
     paint.anti_alias = true;
     let mut pb = tiny_skia::PathBuilder::new();
     let size = 6.0 * scale;
@@ -1881,6 +2005,7 @@ fn render_error_card(
     message: &str,
     cx: f32,
     cy: f32,
+    palette: &OverlayPalette,
 ) {
     let font_size = 14.0;
     let icon_w = 10.0;
@@ -1898,7 +2023,7 @@ fn render_error_card(
     let card_path = rounded_rect(card_x, card_y, card_w, card_h, card_r);
 
     let mut bg_paint = tiny_skia::Paint::default();
-    bg_paint.set_color(tiny_skia::Color::from_rgba(0.06, 0.06, 0.1, 0.75).unwrap());
+    bg_paint.set_color(color_from_rgba8(palette.pill_fill(true)));
     bg_paint.anti_alias = true;
     pixmap.fill_path(
         &card_path,
@@ -1909,7 +2034,7 @@ fn render_error_card(
     );
 
     let mut border_paint = tiny_skia::Paint::default();
-    border_paint.set_color(tiny_skia::Color::from_rgba(1.0, 1.0, 1.0, 0.3).unwrap());
+    border_paint.set_color(color_from_rgba8(palette.border(true)));
     border_paint.anti_alias = true;
     let stroke = tiny_skia::Stroke {
         width: 1.0,
@@ -1946,7 +2071,7 @@ fn render_error_card(
         content_x + icon_w + gap,
         cy + font_size * 0.35,
         font_size,
-        [255, 255, 255, 230],
+        palette.text(230),
     );
 }
 
@@ -1957,6 +2082,7 @@ fn render_onboarding_card(
     hotkey_label: &str,
     cx: f32,
     cy: f32,
+    palette: &OverlayPalette,
 ) {
     let text = onboarding_card_text(step, hotkey_label);
     let font_size = 14.0;
@@ -1973,7 +2099,7 @@ fn render_onboarding_card(
     // Card background
     let card_path = rounded_rect(card_x, card_y, card_w, card_h, card_r);
     let mut bg_paint = tiny_skia::Paint::default();
-    bg_paint.set_color(tiny_skia::Color::from_rgba(0.06, 0.06, 0.1, 0.75).unwrap());
+    bg_paint.set_color(color_from_rgba8(palette.pill_fill(true)));
     bg_paint.anti_alias = true;
     pixmap.fill_path(
         &card_path,
@@ -1985,7 +2111,7 @@ fn render_onboarding_card(
 
     // Card border
     let mut border_paint = tiny_skia::Paint::default();
-    border_paint.set_color(tiny_skia::Color::from_rgba(1.0, 1.0, 1.0, 0.3).unwrap());
+    border_paint.set_color(color_from_rgba8(palette.border(true)));
     border_paint.anti_alias = true;
     let stroke = tiny_skia::Stroke {
         width: 1.0,
@@ -2000,7 +2126,7 @@ fn render_onboarding_card(
         cx,
         cy + font_size * 0.35,
         font_size,
-        [255, 255, 255, 230],
+        palette.text(230),
     );
 }
 
@@ -2011,6 +2137,7 @@ fn render_keycap(
     x: f32,
     cy: f32,
     font_size: f32,
+    palette: &OverlayPalette,
 ) {
     let fr = match font {
         Some(f) => f,
@@ -2026,7 +2153,7 @@ fn render_keycap(
     // Keycap background
     let key_path = rounded_rect(x, ky, kw, kh, 5.0 * ui_scale);
     let mut bg = tiny_skia::Paint::default();
-    bg.set_color(tiny_skia::Color::from_rgba(0.25, 0.25, 0.25, 1.0).unwrap());
+    bg.set_color(color_from_rgba8(palette.key_fill()));
     bg.anti_alias = true;
     pixmap.fill_path(
         &key_path,
@@ -2038,7 +2165,7 @@ fn render_keycap(
 
     // Keycap border
     let mut border = tiny_skia::Paint::default();
-    border.set_color(tiny_skia::Color::from_rgba(0.45, 0.45, 0.45, 1.0).unwrap());
+    border.set_color(color_from_rgba8(palette.key_border()));
     border.anti_alias = true;
     let stroke = tiny_skia::Stroke {
         width: 1.0,
@@ -2053,7 +2180,7 @@ fn render_keycap(
         x + kw / 2.0,
         cy + font_size * 0.35,
         font_size,
-        [255, 255, 255, 255],
+        palette.text(255),
     );
 }
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yap",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Cross-platform voice-to-text tray app",
   "author": "igaboo",
   "type": "module",

--- a/desktop/src/lib/settings/Settings.svelte
+++ b/desktop/src/lib/settings/Settings.svelte
@@ -31,6 +31,7 @@
     type RuntimeUpdate,
   } from '../runtime/yap';
   import {
+    appearanceModes,
     backgroundAudioModes,
     fmtDefaultModels,
     fmtProviders,
@@ -43,6 +44,7 @@
     transcriptionProviders,
     txDefaultModels,
     type AppConfig,
+    type AppearanceMode,
     type BackgroundAudioMode,
     type HistoryEntry,
     type SectionId,
@@ -102,6 +104,7 @@
 
   // Behavior
   let soundsEnabled = $state(true);
+  let appearanceMode = $state<AppearanceMode>('system');
   let backgroundAudioMode = $state<BackgroundAudioMode>('mute');
   let gradientEnabled = $state(true);
   let alwaysVisiblePill = $state(true);
@@ -228,6 +231,7 @@
         oaiPrompt = cfg.oaiPrompt;
         geminiTemperature = cfg.geminiTemperature;
         soundsEnabled = cfg.soundsEnabled;
+        appearanceMode = cfg.appearanceMode ?? 'system';
         backgroundAudioMode = cfg.backgroundAudioMode;
         gradientEnabled = cfg.gradientEnabled;
         alwaysVisiblePill = cfg.alwaysVisiblePill;
@@ -292,6 +296,7 @@
       geminiTemperature,
       elLanguageCode: language.providerCode,
       soundsEnabled,
+      appearanceMode,
       backgroundAudioMode,
       gradientEnabled,
       alwaysVisiblePill,
@@ -347,6 +352,7 @@
     oaiPrompt;
     geminiTemperature;
     soundsEnabled;
+    appearanceMode;
     backgroundAudioMode;
     gradientEnabled;
     alwaysVisiblePill;
@@ -876,6 +882,7 @@
     oaiPrompt = '';
     geminiTemperature = 0;
     soundsEnabled = true;
+    appearanceMode = 'system';
     backgroundAudioMode = 'mute';
     gradientEnabled = true;
     alwaysVisiblePill = true;
@@ -993,11 +1000,11 @@
 <svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />
 
 {#if loading}
-  <div class="settings-container loading-state">
+  <div class="settings-container loading-state" data-appearance-mode={appearanceMode}>
     <span>Loading...</span>
   </div>
 {:else}
-  <div class="settings-container" class:platform-macos={isMac}>
+  <div class="settings-container" class:platform-macos={isMac} data-appearance-mode={appearanceMode}>
     <div class="settings-titlebar" aria-hidden="true"></div>
     <div class="settings-body">
       <aside class="settings-sidebar" aria-label="Settings sections">
@@ -1141,6 +1148,23 @@
                   <span class="toggle-track"></span>
                   <span class="toggle-thumb"></span>
                 </label>
+              </div>
+
+              <div class="field-divider"></div>
+
+              <div class="field-row split">
+                <div class="field-copy">
+                  <span class="field-label">Appearance</span>
+                  <span class="field-description">Match the system or choose a fixed theme.</span>
+                </div>
+                <div class="segmented-control" role="radiogroup" aria-label="Appearance">
+                  {#each appearanceModes as mode}
+                    <label class="segment-option">
+                      <input type="radio" bind:group={appearanceMode} value={mode.value} />
+                      <span>{mode.label}</span>
+                    </label>
+                  {/each}
+                </div>
               </div>
 
               <div class="field-divider"></div>

--- a/desktop/src/lib/settings/metadata.ts
+++ b/desktop/src/lib/settings/metadata.ts
@@ -1,6 +1,7 @@
 export type SectionId = 'general' | 'transcription' | 'formatting' | 'history' | 'advanced';
 export type UpdateStatus = 'idle' | 'checking' | 'available' | 'upToDate' | 'downloading' | 'ready' | 'error';
 export type BackgroundAudioMode = 'off' | 'mute' | 'pause';
+export type AppearanceMode = 'system' | 'light' | 'dark';
 
 export interface AppConfig {
   hotkey: string;
@@ -22,6 +23,7 @@ export interface AppConfig {
   geminiTemperature: number;
   elLanguageCode: string;
   soundsEnabled: boolean;
+  appearanceMode: AppearanceMode;
   backgroundAudioMode: BackgroundAudioMode;
   gradientEnabled: boolean;
   alwaysVisiblePill: boolean;
@@ -134,4 +136,10 @@ export const backgroundAudioModes: Array<{ value: BackgroundAudioMode; label: st
   { value: 'off', label: 'Off' },
   { value: 'mute', label: 'Mute' },
   { value: 'pause', label: 'Pause' },
+];
+
+export const appearanceModes: Array<{ value: AppearanceMode; label: string }> = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
 ];

--- a/desktop/src/lib/settings/settings.css
+++ b/desktop/src/lib/settings/settings.css
@@ -1,14 +1,17 @@
 /* Settings window */
 
 :root {
-  color-scheme: dark;
-  --settings-bg: #1f1f1f;
-  --settings-surface: #252525;
-  --settings-surface-hover: #2d2d2d;
-  --settings-surface-active: #303030;
-  --settings-border: #343434;
-  --settings-border-muted: #1f1f1f;
-  --settings-text-muted: #707070;
+  color-scheme: light dark;
+  --settings-bg: #f4f1ec;
+  --settings-surface: #fffaf3;
+  --settings-surface-hover: #eee9e2;
+  --settings-surface-active: #e8e1d8;
+  --settings-border: #d8d0c6;
+  --settings-border-muted: #ebe3d9;
+  --settings-text-muted: #756f67;
+  --settings-text-muted-active: #5f5850;
+  --settings-badge-bg: #ece6dd;
+  --settings-badge-text: #6e665d;
   --settings-primary: #0a84ff;
   --settings-primary-hover: #409cff;
   --settings-primary-soft: rgba(10, 132, 255, 0.14);
@@ -17,6 +20,22 @@
   --settings-radius-button: 7px;
   --settings-font: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', 'Helvetica Neue', sans-serif;
   --settings-mono: 'SF Mono', 'Menlo', 'Consolas', monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --settings-bg: #1f1f1f;
+    --settings-surface: #252525;
+    --settings-surface-hover: #2d2d2d;
+    --settings-surface-active: #303030;
+    --settings-border: #343434;
+    --settings-border-muted: #1f1f1f;
+    --settings-text-muted: #707070;
+    --settings-text-muted-active: #9a9a9a;
+    --settings-badge-bg: #2a2a2a;
+    --settings-badge-text: #9a9a9a;
+  }
 }
 
 * {
@@ -62,6 +81,34 @@ label {
   font-size: 13px;
   line-height: 1.4;
   -webkit-font-smoothing: antialiased;
+}
+
+.settings-container[data-appearance-mode='light'] {
+  color-scheme: light;
+  --settings-bg: #f4f1ec;
+  --settings-surface: #fffaf3;
+  --settings-surface-hover: #eee9e2;
+  --settings-surface-active: #e8e1d8;
+  --settings-border: #d8d0c6;
+  --settings-border-muted: #ebe3d9;
+  --settings-text-muted: #756f67;
+  --settings-text-muted-active: #5f5850;
+  --settings-badge-bg: #ece6dd;
+  --settings-badge-text: #6e665d;
+}
+
+.settings-container[data-appearance-mode='dark'] {
+  color-scheme: dark;
+  --settings-bg: #1f1f1f;
+  --settings-surface: #252525;
+  --settings-surface-hover: #2d2d2d;
+  --settings-surface-active: #303030;
+  --settings-border: #343434;
+  --settings-border-muted: #1f1f1f;
+  --settings-text-muted: #707070;
+  --settings-text-muted-active: #9a9a9a;
+  --settings-badge-bg: #2a2a2a;
+  --settings-badge-text: #9a9a9a;
 }
 
 .settings-container.platform-macos {
@@ -188,7 +235,7 @@ label {
 }
 
 .section-nav-item.active .section-nav-description {
-  color: #9a9a9a;
+  color: var(--settings-text-muted-active);
 }
 
 .settings-main {
@@ -784,8 +831,8 @@ label {
   padding: 0 7px;
   border: 1px solid var(--settings-border);
   border-radius: 999px;
-  background: #2a2a2a;
-  color: #9a9a9a;
+  background: var(--settings-badge-bg);
+  color: var(--settings-badge-text);
   font-size: 10px;
   font-weight: 600;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- feat: add an Appearance segmented control with System, Light, and Dark modes
- feat: apply the appearance preference across Settings, Electron windows, and native overlays
- chore: bump version to 4.1.0

## Testing
- [x] `pnpm run electron:check`
- [x] `pnpm run check`
- [x] `cargo check --manifest-path native-core/Cargo.toml --bin yap-core`
- [x] `cargo fmt --check --manifest-path native-core/Cargo.toml`
- [x] `git diff --check`
- [x] `pnpm run electron:build`

## Version Bump Files
- `desktop/package.json`
- `desktop/native-core/Cargo.toml`
- `desktop/native-core/Cargo.lock`

## Release Notes Preview
## What's Changed
* feat: add app-wide appearance modes by @oobagi in this PR
* feat: theme Settings and native overlays from the appearance preference by @oobagi in this PR
* chore: bump version to 4.1.0 by @oobagi in this PR


**Full Changelog**: https://github.com/oobagi/yap/compare/v4.0.0...v4.1.0
